### PR TITLE
Implement Batter Thermistor Fault

### DIFF
--- a/Core/Inc/bmsConfig.h
+++ b/Core/Inc/bmsConfig.h
@@ -28,6 +28,8 @@
 #define MAX_CELL_CURR       700 // Amps per BMS cell
 #define MAX_CELL_TEMP_BAL   45
 #define MAX_CHG_CELL_CURR   20  
+#define THERMISTOR_MIN_TEMP -40 // minimum safe temp in Celsius
+#define THERMISTOR_MAX_TEMP 85 // maximum safe temp in Celsius
 
 // Algorithm settings
 #define CHARGE_TIMEOUT      300000 // 5 minutes, may need adjustment
@@ -48,6 +50,7 @@
 #define LOW_CELL_TIME       15000
 #define HIGH_TEMP_TIME      60000
 #define CURR_ERR_MARG       50       // in A * 10
+#define THERMISTOR_TIME     5000
 
 #define DCDC_CURRENT_DRAW   2 // in A, this is generous
 

--- a/Core/Inc/stateMachine.h
+++ b/Core/Inc/stateMachine.h
@@ -21,6 +21,8 @@ class StateMachine
         tristate_timer overVolt_tmr;
         tristate_timer lowCell_tmr;
         tristate_timer highTemp_tmr;
+        tristate_timer highThermTemp_tmr;
+        tristate_timer lowThermTemp_tmr;
 
         tristate_timer prefaultOverCurr_tmr;
         tristate_timer prefaultLowCell_tmr;

--- a/Core/Src/stateMachine.cpp
+++ b/Core/Src/stateMachine.cpp
@@ -208,6 +208,8 @@ uint32_t StateMachine::faultReturn(AccumulatorData_t *accData)
             {.id = "High Cell Voltage",       .timer =       overVolt_tmr, .data_1 = accData->max_voltage.val, .optype_1 = GT, .lim_1 =                                       MAX_VOLT * 10000, .timeout =      OVER_VOLT_TIME,	.code =            CELL_VOLTAGE_TOO_HIGH,   .data_2 = accData->is_charger_connected, .optype_2 = EQ, .lim_2 =         false }, 
             {.id = "High Temp",               .timer =       highTemp_tmr, .data_1 =    accData->max_temp.val, .optype_1 = GT, .lim_1 =                                          MAX_CELL_TEMP,	.timeout =       LOW_CELL_TIME,	.code =                     PACK_TOO_HOT   /* -----------------------------------UNUSED---------------------------------*/  }, 
             {.id = "Extremely Low Voltage",   .timer =        lowCell_tmr, .data_1 = accData->min_voltage.val, .optype_1 = LT, .lim_1 =                                                    900, .timeout =      HIGH_TEMP_TIME,	.code =                 LOW_CELL_VOLTAGE   /* -----------------------------------UNUSED---------------------------------*/  }, 
+			{.id = "High Thermistor Temp",    .timer =  highThermTemp_tmr, .data_1 = accData->thermistor_temp, .optype_1 = GT, .lim_1 =                                    THERMISTOR_MAX_TEMP, .timeout =      THERMISTOR_TIME,.code =       THERMISTOR_OVER_TEMP_FAULT																					},
+			{.id = "Low Thermistor Temp",     .timer =   lowThermTemp_tmr, .data_1 = accData->thermistor_temp, .optype_1 = LT, .lim_1 =                                    THERMISTOR_MIN_TEMP, .timeout =      THERMISTOR_TIME,.code =      THERMISTOR_UNDER_TEMP_FAULT                             														},
 
             NULL
         };


### PR DESCRIPTION
Implemented battery thermistor fault in statemachine.cpp. Defined max_tem and min_temp, as well as timer length in bmsconfig.h. Defined timers in statemachine.h #29 