### PR TITLE
Added non-critical faults and included test in can_handler.c

### DIFF
--- a/Core/Inc/datastructs.h
+++ b/Core/Inc/datastructs.h
@@ -59,6 +59,17 @@ typedef enum {
 // clang-format on
 
 /**
+ * @brief Enuemrated possible non-critical fault codes for the BMS
+ * @note  the values increase at powers of two to perform bitwise operations on a main fault code
+ *          to set or get the error codes
+ */
+typedef enum {
+	/* non-critical cases */
+	FAILED_CAN_RECEIVAL					= 0x1,
+
+} bms_nc_fault_t;
+
+/**
  * @brief Stores critical values for the pack, and where that critical value can be found
  *
  */
@@ -122,6 +133,23 @@ typedef struct {
 
 	bool is_charger_connected;
 } acc_data_t;
+
+typedef struct 
+{
+	nertimer_t timer;
+	int timeout;
+
+	int can_receivals;
+	
+
+	/**
+	 * @brief Note that this is a 32 bit integer, so there are 32 max possible fault codes
+	 */
+	uint32_t fault_code;
+	uint32_t fault_status;
+
+} nc_fault_collection_t;
+
 
 /**
  * @brief Represents individual BMS states

--- a/Core/Inc/datastructs.h
+++ b/Core/Inc/datastructs.h
@@ -136,18 +136,9 @@ typedef struct {
 
 typedef struct 
 {
-	nertimer_t timer;
-	int timeout;
+	bms_fault_t fault_code;
 
-	int can_receivals;
-	
-
-	/**
-	 * @brief Note that this is a 32 bit integer, so there are 32 max possible fault codes
-	 */
-	uint32_t fault_code;
-	uint32_t fault_status;
-
+	uint8_t can_fault;
 } nc_fault_collection_t;
 
 

--- a/Core/Inc/stateMachine.h
+++ b/Core/Inc/stateMachine.h
@@ -48,6 +48,15 @@ uint32_t sm_fault_return(acc_data_t *accData);
  */
 uint32_t sm_fault_eval(fault_eval_t* index);
 
+ /**
+ * @brief Used to collect non-critical fault codes to append to the current status
+ * 
+ * @param nc_fault_data
+ * @param fault_code
+ * @return fault_code
+ */
+void sm_nc_fault_collect(nc_fault_collection_t *nc_fault_data);
+
 /**
  * @brief handles the state machine, calls the appropriate handler function and runs every loop functions
  * 

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -5,7 +5,7 @@
 
 ringbuffer_t* can1_rx_queue = NULL;
 ringbuffer_t* can2_rx_queue = NULL;
-nc_fault_collection_t* nc_fault_collection = NULL;
+nc_fault_collection_t nc_fault_collection;
 
 void can_receive_callback(CAN_HandleTypeDef* hcan)
 {
@@ -15,13 +15,11 @@ void can_receive_callback(CAN_HandleTypeDef* hcan)
 	/* Read in CAN message */
 	if (HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, &rx_header, new_msg.data) != HAL_OK) {
 		
-		nc_fault_collection->fault_code = FAILED_CAN_RECEIVAL;
-		sm_nc_fault_collect(nc_fault_collection);
+		nc_fault_collection.fault_code = FAILED_CAN_RECEIVAL;
+		sm_nc_fault_collect(&nc_fault_collection);
 		// TODO add non crtical fault capability - could create one for failed can receieve
 		return;
 	}
-	
-	nc_fault_collection->can_receivals += 1;
 	new_msg.len = rx_header.DLC;
 	new_msg.id	= rx_header.StdId;
 	if (hcan == &hcan1) {

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -1,21 +1,27 @@
 #include "analyzer.h"
 #include "ringbuffer.h"
 #include "can_handler.h"
+#include "stateMachine.h"
 
 ringbuffer_t* can1_rx_queue = NULL;
 ringbuffer_t* can2_rx_queue = NULL;
+nc_fault_collection_t* nc_fault_collection = NULL;
 
 void can_receive_callback(CAN_HandleTypeDef* hcan)
 {
 	CAN_RxHeaderTypeDef rx_header;
 	can_msg_t new_msg;
+
 	/* Read in CAN message */
 	if (HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, &rx_header, new_msg.data) != HAL_OK) {
-
+		
+		nc_fault_collection->fault_code = FAILED_CAN_RECEIVAL;
+		sm_nc_fault_collect(nc_fault_collection);
 		// TODO add non crtical fault capability - could create one for failed can receieve
 		return;
 	}
-
+	
+	nc_fault_collection->can_receivals += 1;
 	new_msg.len = rx_header.DLC;
 	new_msg.id	= rx_header.StdId;
 	if (hcan == &hcan1) {

--- a/Core/Src/stateMachine.c
+++ b/Core/Src/stateMachine.c
@@ -293,25 +293,9 @@ uint32_t sm_fault_eval(fault_eval_t* index)
 }
 
 void sm_nc_fault_collect(nc_fault_collection_t *nc_fault_data) {
-
-	bool condition;
-
 	switch (nc_fault_data->fault_code) {
-		case FAILED_CAN_RECEIVAL: condition = nc_fault_data->can_receivals == 0; break;
-		default: true;
-	}
-
-	if (!is_timer_active(&nc_fault_data->timer) && condition)
-	{
-		start_timer(&nc_fault_data->timer, nc_fault_data->timeout);
-	}
-	else {
-		if (is_timer_expired(&nc_fault_data->timer)) {
-			nc_fault_data->fault_status |= nc_fault_data->fault_code;
-		}
-		if (!condition) {
-			cancel_timer(&nc_fault_data->timer);
-		}
+		case FAILED_CAN_RECEIVAL: nc_fault_data->can_fault += 1; break;
+		default: break;
 	}
 }
 


### PR DESCRIPTION
## Changes

Added a collection system for non-critical faults and also made a test example for when CAN does not fails to receive a message.

## Notes

Hopefully this system works for non critical faults. Also, I was not sure how and where to initialize a timeout for the nertimer to check if the condition is true for a certain duration of time before adding the fault code to the fault status.

## Test Cases

- Failed can message receival 

## To Do

_Any remaining things that need to get done_

- [ ] Add more non-critical faults

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] No merge conflicts
- [X] All checks passing
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [X] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #81
