### PR TITLE
Get CAN out of state machine

### DIFF
--- a/Core/Inc/bmsConfig.h
+++ b/Core/Inc/bmsConfig.h
@@ -64,4 +64,6 @@
 
 // #define CHARGING
 
+#define SAMPLE_RATE 2 /* Hz */
+
 #endif

--- a/Core/Inc/compute.h
+++ b/Core/Inc/compute.h
@@ -81,9 +81,9 @@ uint8_t compute_set_fan_speed(TIM_HandleTypeDef *pwmhandle,
 int16_t compute_get_pack_current();
 
 /**
- * @brief sends max discharge current to Motor Controller
+ * @brief Sends max discharge current to Motor Controller.
  *
- * @param bmsdata
+ * @param bmsdata data structure containing the discharge limit
  */
 void compute_send_mc_discharge_message(acc_data_t *bmsdata);
 

--- a/Core/Inc/compute.h
+++ b/Core/Inc/compute.h
@@ -129,6 +129,7 @@ void compute_send_bms_status_message(acc_data_t *bmsdata, int bms_state,
 
 /**
  * @brief sends shutdown control message
+ * @note unused
  *
  * @param mpe_state
  *
@@ -189,9 +190,23 @@ void compute_send_segment_temp_message(acc_data_t *bmsdata);
 
 void compute_send_fault_message(uint8_t status, int16_t curr, int16_t in_dcl);
 
+/**
+ * @brief Send CAN message for debugging the car on the fly.
+ * 
+ * @param debug0 
+ * @param debug1 
+ * @param debug2 
+ * @param debug3 
+ */
 void compute_send_debug_message(uint8_t debug0, uint8_t debug1, uint16_t debug2,
 				uint32_t debug3);
 
+/**
+ * @brief Send CAN message containing voltage noise data.
+ * @note Unused
+ * 
+ * @param bmsdata 
+ */
 void compute_send_voltage_noise_message(acc_data_t *bmsdata);
 
 #endif // COMPUTE_H

--- a/Core/Inc/segment.h
+++ b/Core/Inc/segment.h
@@ -53,6 +53,7 @@ bool cell_is_balancing(uint8_t chip_num, uint8_t cell_num);
 
 /**
  * @brief Returns if any cells are balancing
+ * @todo This should just be a state variable -Scott
  *
  * @return true
  * @return false

--- a/Core/Inc/shep_tasks.h
+++ b/Core/Inc/shep_tasks.h
@@ -13,6 +13,8 @@
 
 #include "cmsis_os2.h"
 
+#define CAN_DISPATCH_FLAG 1
+
 /**
  * @brief Task for retrieving segment data
  * 

--- a/Core/Src/analyzer.c
+++ b/Core/Src/analyzer.c
@@ -279,6 +279,8 @@ void calc_pack_temps(acc_data_t *bmsdata)
 
 	/* takes the average of all the cell temperatures */
 	bmsdata->avg_temp = total_temp / (total_accepted);
+
+	// compute_send_cell_temp_message
 }
 
 void calc_pack_voltage_stats(acc_data_t *bmsdata)
@@ -349,12 +351,15 @@ void calc_pack_voltage_stats(acc_data_t *bmsdata)
 	/* calculate some voltage stats */
 	bmsdata->avg_voltage = total_volt / (NUM_CELLS_PER_CHIP * NUM_CHIPS);
 	bmsdata->pack_voltage = total_volt / 1000; /* convert to voltage * 10 */
+	// compute_send_acc_status_message
 	bmsdata->delt_voltage =
 		bmsdata->max_voltage.val - bmsdata->min_voltage.val;
 
 	bmsdata->avg_ocv = total_ocv / (NUM_CELLS_PER_CHIP * NUM_CHIPS);
 	bmsdata->pack_ocv = total_ocv / 1000; /* convert to voltage * 10 */
 	bmsdata->delt_ocv = bmsdata->max_ocv.val - bmsdata->min_ocv.val;
+
+	// compute_send_cell_data_message
 }
 
 void calc_cell_resistances(acc_data_t *bmsdata)
@@ -450,6 +455,9 @@ void calc_dcl(acc_data_t *bmsdata)
 		bmsdata->discharge_limit -= DCDC_CURRENT_DRAW;
 		prev_dcl -= DCDC_CURRENT_DRAW;
 	}
+
+	// discharge_limit: compute_send_mc_discharge_message
+	// compute_send_current_message
 }
 
 void calc_cont_dcl(acc_data_t *bmsdata)
@@ -494,6 +502,9 @@ void calcCCL(acc_data_t *bmsdata)
 	} else {
 		bmsdata->charge_limit = currentLimit;
 	}
+
+	// charge_limit: compute_send_mc_charge_message
+	// compute_send_current_message
 }
 
 void calc_cont_ccl(acc_data_t *bmsdata)
@@ -654,6 +665,8 @@ void calc_state_of_charge(acc_data_t *bmsdata)
 	if (bmsdata->soc < 0) {
 		bmsdata->soc = 0;
 	}
+
+	// compute_send_acc_status_message
 }
 
 void calc_noise_volt_percent(acc_data_t *bmsdata)

--- a/Core/Src/analyzer.c
+++ b/Core/Src/analyzer.c
@@ -1,6 +1,9 @@
 #include "analyzer.h"
+
 #include <stdlib.h>
 #include <stdio.h>
+
+#include "compute.h"
 
 // clang-format off
 /**
@@ -280,7 +283,7 @@ void calc_pack_temps(acc_data_t *bmsdata)
 	/* takes the average of all the cell temperatures */
 	bmsdata->avg_temp = total_temp / (total_accepted);
 
-	// compute_send_cell_temp_message
+	compute_send_cell_temp_message(bmsdata);
 }
 
 void calc_pack_voltage_stats(acc_data_t *bmsdata)
@@ -351,7 +354,6 @@ void calc_pack_voltage_stats(acc_data_t *bmsdata)
 	/* calculate some voltage stats */
 	bmsdata->avg_voltage = total_volt / (NUM_CELLS_PER_CHIP * NUM_CHIPS);
 	bmsdata->pack_voltage = total_volt / 1000; /* convert to voltage * 10 */
-	// compute_send_acc_status_message
 	bmsdata->delt_voltage =
 		bmsdata->max_voltage.val - bmsdata->min_voltage.val;
 
@@ -359,7 +361,8 @@ void calc_pack_voltage_stats(acc_data_t *bmsdata)
 	bmsdata->pack_ocv = total_ocv / 1000; /* convert to voltage * 10 */
 	bmsdata->delt_ocv = bmsdata->max_ocv.val - bmsdata->min_ocv.val;
 
-	// compute_send_cell_data_message
+	compute_send_acc_status_message(bmsdata);
+	compute_send_cell_data_message(bmsdata);
 }
 
 void calc_cell_resistances(acc_data_t *bmsdata)
@@ -456,8 +459,8 @@ void calc_dcl(acc_data_t *bmsdata)
 		prev_dcl -= DCDC_CURRENT_DRAW;
 	}
 
-	// discharge_limit: compute_send_mc_discharge_message
-	// compute_send_current_message
+	compute_send_mc_discharge_message(bmsdata);
+	compute_send_current_message(bmsdata);
 }
 
 void calc_cont_dcl(acc_data_t *bmsdata)
@@ -503,8 +506,8 @@ void calcCCL(acc_data_t *bmsdata)
 		bmsdata->charge_limit = currentLimit;
 	}
 
-	// charge_limit: compute_send_mc_charge_message
-	// compute_send_current_message
+	compute_send_mc_charge_message(bmsdata);
+	compute_send_current_message(bmsdata);
 }
 
 void calc_cont_ccl(acc_data_t *bmsdata)
@@ -666,7 +669,7 @@ void calc_state_of_charge(acc_data_t *bmsdata)
 		bmsdata->soc = 0;
 	}
 
-	// compute_send_acc_status_message
+	compute_send_acc_status_message(bmsdata);
 }
 
 void calc_noise_volt_percent(acc_data_t *bmsdata)

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -1,6 +1,8 @@
 #include "analyzer.h"
 #include "ringbuffer.h"
 #include "can_handler.h"
+#include "shep_tasks.h"
+#include <stdio.h>
 
 ringbuffer_t *can1_rx_queue = NULL;
 ringbuffer_t *can2_rx_queue = NULL;
@@ -72,5 +74,13 @@ osStatus_t queue_can_msg(can_msg_t msg)
 	if (!can_outbound_queue)
 		return -1;
 
-	return osMessageQueuePut(can_outbound_queue, &msg, 0U, 0U);
+	osStatus_t res = osMessageQueuePut(can_outbound_queue, &msg, 0U, 0U);
+
+	if (res) {
+		printf("CAN Queue full\r\n");
+	}
+
+	osThreadFlagsSet(can_dispatch_thread, CAN_DISPATCH_FLAG);
+
+	return res;
 }

--- a/Core/Src/compute.c
+++ b/Core/Src/compute.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "bmsConfig.h"
+#include "can_handler.h"
 
 #define MAX_CAN1_STORAGE 10
 #define MAX_CAN2_STORAGE 10
@@ -296,7 +297,7 @@ void compute_send_mc_discharge_message(acc_data_t *bmsdata)
 	mc_msg.len = 8;
 	memcpy(mc_msg.data, &discharge_data, sizeof(discharge_data));
 
-	can_send_msg(&can1, &mc_msg);
+	queue_can_msg(mc_msg);
 }
 
 void compute_send_mc_charge_message(acc_data_t *bmsdata)
@@ -317,7 +318,7 @@ void compute_send_mc_charge_message(acc_data_t *bmsdata)
 	mc_msg.len = 8;
 	memcpy(mc_msg.data, &charge_data, sizeof(charge_data));
 
-	can_send_msg(&can1, &mc_msg);
+	queue_can_msg(mc_msg);
 }
 
 void compute_send_acc_status_message(acc_data_t *bmsdata)
@@ -356,7 +357,7 @@ void compute_send_acc_status_message(acc_data_t *bmsdata)
 	can_t *line = &can1;
 #endif
 
-	can_send_msg(line, &acc_msg);
+	queue_can_msg(acc_msg);
 }
 
 void compute_send_bms_status_message(acc_data_t *bmsdata, int bms_state,
@@ -374,7 +375,8 @@ void compute_send_bms_status_message(acc_data_t *bmsdata, int bms_state,
 	bms_status_msg_data.state = (uint8_t)(bms_state);
 	bms_status_msg_data.fault = bmsdata->fault_code;
 	bms_status_msg_data.temp_internal = (uint8_t)(0);
-	bms_status_msg_data.balance = (uint8_t)(balance); // segment_is_balancing() 
+	bms_status_msg_data.balance =
+		(uint8_t)(balance); // segment_is_balancing()
 
 	/* convert to big endian */
 	endian_swap(&bms_status_msg_data.fault,
@@ -390,7 +392,7 @@ void compute_send_bms_status_message(acc_data_t *bmsdata, int bms_state,
 #else
 	can_t *line = &can1;
 #endif
-	can_send_msg(line, &acc_msg);
+	queue_can_msg(acc_msg);
 }
 
 void compute_send_shutdown_ctrl_message(uint8_t mpe_state)
@@ -413,7 +415,7 @@ void compute_send_shutdown_ctrl_message(uint8_t mpe_state)
 	can_t *line = &can1;
 #endif
 
-	can_send_msg(line, &acc_msg);
+	queue_can_msg(acc_msg);
 }
 
 void compute_send_cell_data_message(acc_data_t *bmsdata)
@@ -454,7 +456,7 @@ void compute_send_cell_data_message(acc_data_t *bmsdata)
 	can_t *line = &can1;
 #endif
 
-	can_send_msg(line, &acc_msg);
+	queue_can_msg(acc_msg);
 }
 
 void compute_send_cell_voltage_message(uint8_t cell_id,
@@ -496,7 +498,7 @@ void compute_send_cell_voltage_message(uint8_t cell_id,
 	can_t *line = &can1;
 #endif
 
-	can_send_msg(line, &acc_msg);
+	queue_can_msg(acc_msg);
 }
 
 void compute_send_current_message(acc_data_t *bmsdata)
@@ -531,7 +533,7 @@ void compute_send_current_message(acc_data_t *bmsdata)
 	can_t *line = &can1;
 #endif
 
-	can_send_msg(line, &acc_msg);
+	queue_can_msg(acc_msg);
 }
 
 void compute_send_cell_temp_message(acc_data_t *bmsdata)
@@ -571,7 +573,7 @@ void compute_send_cell_temp_message(acc_data_t *bmsdata)
 	can_t *line = &can1;
 #endif
 
-	can_send_msg(line, &acc_msg);
+	queue_can_msg(acc_msg);
 }
 
 void compute_send_segment_temp_message(acc_data_t *bmsdata)
@@ -611,7 +613,7 @@ void compute_send_segment_temp_message(acc_data_t *bmsdata)
 	can_t *line = &can1;
 #endif
 
-	can_send_msg(line, &acc_msg);
+	queue_can_msg(acc_msg);
 }
 
 void compute_send_fault_message(uint8_t status, int16_t curr, int16_t in_dcl)
@@ -641,7 +643,7 @@ void compute_send_fault_message(uint8_t status, int16_t curr, int16_t in_dcl)
 	can_t *line = &can1;
 #endif
 
-	can_send_msg(line, &acc_msg);
+	queue_can_msg(acc_msg);
 }
 
 void compute_send_voltage_noise_message(acc_data_t *bmsdata)
@@ -680,7 +682,7 @@ void compute_send_voltage_noise_message(acc_data_t *bmsdata)
 	can_t *line = &can1;
 #endif
 
-	can_send_msg(line, &acc_msg);
+	queue_can_msg(acc_msg);
 }
 
 void compute_send_debug_message(uint8_t debug0, uint8_t debug1, uint16_t debug2,
@@ -713,7 +715,7 @@ void compute_send_debug_message(uint8_t debug0, uint8_t debug1, uint16_t debug2,
 	can_t *line = &can1;
 #endif
 
-	can_send_msg(line, &debug_msg);
+	queue_can_msg(debug_msg);
 }
 
 void change_adc1_channel(uint8_t channel)

--- a/Core/Src/compute.c
+++ b/Core/Src/compute.c
@@ -351,12 +351,6 @@ void compute_send_acc_status_message(acc_data_t *bmsdata)
 	acc_msg.len = sizeof(acc_status_msg_data);
 	memcpy(acc_msg.data, &acc_status_msg_data, sizeof(acc_status_msg_data));
 
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
-
 	queue_can_msg(acc_msg);
 }
 
@@ -387,11 +381,6 @@ void compute_send_bms_status_message(acc_data_t *bmsdata, int bms_state,
 	acc_msg.len = sizeof(bms_status_msg_data);
 	memcpy(acc_msg.data, &bms_status_msg_data, sizeof(bms_status_msg_data));
 
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
 	queue_can_msg(acc_msg);
 }
 
@@ -408,12 +397,6 @@ void compute_send_shutdown_ctrl_message(uint8_t mpe_state)
 	acc_msg.len = sizeof(shutdown_control_msg_data);
 	memcpy(acc_msg.data, &shutdown_control_msg_data,
 	       sizeof(shutdown_control_msg_data));
-
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
 
 	queue_can_msg(acc_msg);
 }
@@ -449,12 +432,6 @@ void compute_send_cell_data_message(acc_data_t *bmsdata)
 	acc_msg.id = 0x83;
 	acc_msg.len = sizeof(cell_data_msg_data);
 	memcpy(acc_msg.data, &cell_data_msg_data, sizeof(cell_data_msg_data));
-
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
 
 	queue_can_msg(acc_msg);
 }
@@ -492,12 +469,6 @@ void compute_send_cell_voltage_message(uint8_t cell_id,
 	memcpy(acc_msg.data, &cell_voltage_msg_data,
 	       sizeof(cell_voltage_msg_data));
 
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
-
 	queue_can_msg(acc_msg);
 }
 
@@ -526,12 +497,6 @@ void compute_send_current_message(acc_data_t *bmsdata)
 	acc_msg.len = sizeof(current_status_msg_data);
 	memcpy(acc_msg.data, &current_status_msg_data,
 	       sizeof(current_status_msg_data));
-
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
 
 	queue_can_msg(acc_msg);
 }
@@ -567,12 +532,6 @@ void compute_send_cell_temp_message(acc_data_t *bmsdata)
 	acc_msg.len = sizeof(cell_temp_msg_data);
 	memcpy(acc_msg.data, &cell_temp_msg_data, sizeof(cell_temp_msg_data));
 
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
-
 	queue_can_msg(acc_msg);
 }
 
@@ -607,12 +566,6 @@ void compute_send_segment_temp_message(acc_data_t *bmsdata)
 	memcpy(acc_msg.data, &segment_temp_msg_data,
 	       sizeof(segment_temp_msg_data));
 
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
-
 	queue_can_msg(acc_msg);
 }
 
@@ -636,12 +589,6 @@ void compute_send_fault_message(uint8_t status, int16_t curr, int16_t in_dcl)
 	acc_msg.id = 0x703;
 	acc_msg.len = 5;
 	memcpy(acc_msg.data, &fault_msg_data, sizeof(fault_msg_data));
-
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
 
 	queue_can_msg(acc_msg);
 }
@@ -676,12 +623,6 @@ void compute_send_voltage_noise_message(acc_data_t *bmsdata)
 	memcpy(acc_msg.data, &voltage_noise_msg_data,
 	       sizeof(voltage_noise_msg_data));
 
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
-
 	queue_can_msg(acc_msg);
 }
 
@@ -708,12 +649,6 @@ void compute_send_debug_message(uint8_t debug0, uint8_t debug1, uint16_t debug2,
 	endian_swap(&debug_msg_data.debug3, sizeof(debug_msg_data.debug3));
 
 	memcpy(debug_msg.data, &debug_msg_data, 8);
-
-#ifdef CHARGING_ENABLED
-	can_t *line = &can2;
-#else
-	can_t *line = &can1;
-#endif
 
 	queue_can_msg(debug_msg);
 }

--- a/Core/Src/compute.c
+++ b/Core/Src/compute.c
@@ -374,7 +374,7 @@ void compute_send_bms_status_message(acc_data_t *bmsdata, int bms_state,
 	bms_status_msg_data.state = (uint8_t)(bms_state);
 	bms_status_msg_data.fault = bmsdata->fault_code;
 	bms_status_msg_data.temp_internal = (uint8_t)(0);
-	bms_status_msg_data.balance = (uint8_t)(balance);
+	bms_status_msg_data.balance = (uint8_t)(balance); // segment_is_balancing() 
 
 	/* convert to big endian */
 	endian_swap(&bms_status_msg_data.fault,
@@ -613,6 +613,7 @@ void compute_send_segment_temp_message(acc_data_t *bmsdata)
 
 	can_send_msg(line, &acc_msg);
 }
+
 void compute_send_fault_message(uint8_t status, int16_t curr, int16_t in_dcl)
 {
 	struct __attribute__((__packed__)) {

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -1178,7 +1178,9 @@ void watchdog_pet(void)
 void StartDefaultTask(void *argument)
 {
   /* USER CODE BEGIN 5 */
+  #ifdef DEBUG_STATS
   acc_data_t* bmsdata = (acc_data_t*) argument;
+  #endif
 
   bool alt = true;
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -302,14 +302,14 @@ int main(void)
   //watchdog_init();
   segment_init();
   compute_init();
-  
+  printf("Init passed\r\n");
   /* USER CODE END 2 */
 
   /* Init scheduler */
   osKernelInitialize();
 
   /* USER CODE BEGIN RTOS_MUTEX */
-  /* add mutexes, ... */
+  acc_data->mutex = osMutexNew(NULL);
   /* USER CODE END RTOS_MUTEX */
 
   /* USER CODE BEGIN RTOS_SEMAPHORES */
@@ -1178,6 +1178,8 @@ void watchdog_pet(void)
 void StartDefaultTask(void *argument)
 {
   /* USER CODE BEGIN 5 */
+  acc_data_t* bmsdata = (acc_data_t*) argument;
+
   bool alt = true;
 
   /* Infinite loop */

--- a/Core/Src/shep_tasks.c
+++ b/Core/Src/shep_tasks.c
@@ -14,10 +14,9 @@
 #include "can_handler.h"
 #include "analyzer.h"
 #include "compute.h"
+#include <stdio.h>
 
 #define STATE_MACHINE_FLAG 1
-
-#define CAN_DISPATCH_FLAG 1
 
 #define ANALYZER_FLAG 1
 
@@ -32,7 +31,7 @@ void vGetSegmentData(void *pv_params)
 	for (;;) {
 		segment_retrieve_data(bmsdata->chip_data);
 		osThreadFlagsSet(analyzer_thread, ANALYZER_FLAG);
-		osThreadYield();
+		osDelay(1000 / SAMPLE_RATE);
 	}
 }
 
@@ -45,6 +44,7 @@ void vAnalyzer(void *pv_params)
 	acc_data_t *bmsdata = (acc_data_t *)pv_params;
 	for (;;) {
 		osThreadFlagsWait(ANALYZER_FLAG, osFlagsWaitAny, osWaitForever);
+
 		osMutexAcquire(bmsdata->mutex, osWaitForever);
 		disable_therms(bmsdata);
 
@@ -57,14 +57,16 @@ void vAnalyzer(void *pv_params)
 		calc_cont_dcl(bmsdata);
 		//calcCCL();
 		calc_cont_ccl(bmsdata);
+		// temporary
+		bmsdata->charge_limit = bmsdata->cont_CCL;
+		compute_send_mc_charge_message(bmsdata);
+		compute_send_current_message(bmsdata);
+		// temporary end
+
 		calc_state_of_charge(bmsdata);
 		calc_noise_volt_percent(bmsdata);
 
-		bmsdata->charge_limit = bmsdata->cont_CCL;
-		// compute_send_current_message
-
 		osMutexRelease(bmsdata->mutex);
-		osThreadYield();
 	}
 }
 
@@ -77,9 +79,9 @@ void vCurrentMonitor(void *pv_params)
 	acc_data_t *bmsdata = (acc_data_t *)pv_params;
 	for (;;) {
 		bmsdata->pack_current = compute_get_pack_current();
-		//compute_send_acc_status_message
-		//compute_send_current_message
-		osDelay(100);
+		compute_send_acc_status_message(bmsdata);
+		compute_send_current_message(bmsdata);
+		osDelay(1000 / SAMPLE_RATE);
 	}
 }
 
@@ -121,13 +123,16 @@ void vCanDispatch(void *pv_params)
 
 		/* Send all CAN messages in the queue */
 		while (osOK == osMessageQueueGet(can_outbound_queue,
-					      &msg_from_queue, NULL,
-					      osWaitForever)) {
+						 &msg_from_queue, NULL, 0)) {
 			msg_status = can_send_msg(line, &msg_from_queue);
 			if (msg_status == HAL_ERROR) {
+				// temporary
+				printf("CAN ERROR\r\n");
 				// TODO: error handling
 				// fault_data.diag = "Failed to send CAN message";
 			} else if (msg_status == HAL_BUSY) {
+				// temporary
+				printf("CAN BUSY\r\n");
 				// TODO: error handling
 				//"Outbound mailbox full!";
 			}

--- a/Core/Src/shep_tasks.c
+++ b/Core/Src/shep_tasks.c
@@ -61,6 +61,7 @@ void vAnalyzer(void *pv_params)
 		calc_noise_volt_percent(bmsdata);
 
 		bmsdata->charge_limit = bmsdata->cont_CCL;
+		// compute_send_current_message
 
 		osMutexRelease(bmsdata->mutex);
 		osThreadYield();
@@ -76,6 +77,8 @@ void vCurrentMonitor(void *pv_params)
 	acc_data_t *bmsdata = (acc_data_t *)pv_params;
 	for (;;) {
 		bmsdata->pack_current = compute_get_pack_current();
+		//compute_send_acc_status_message
+		//compute_send_current_message
 		osDelay(100);
 	}
 }
@@ -115,8 +118,9 @@ void vCanDispatch(void *pv_params)
 	for (;;) {
 		osThreadFlagsWait(CAN_DISPATCH_FLAG, osFlagsWaitAny,
 				  osFlagsWaitAny);
-		/* Send CAN message */
-		if (osOK == osMessageQueueGet(can_outbound_queue,
+
+		/* Send all CAN messages in the queue */
+		while (osOK == osMessageQueueGet(can_outbound_queue,
 					      &msg_from_queue, NULL,
 					      osWaitForever)) {
 			msg_status = can_send_msg(line, &msg_from_queue);

--- a/Core/Src/stateMachine.c
+++ b/Core/Src/stateMachine.c
@@ -167,7 +167,7 @@ void handle_faulted(acc_data_t *bmsdata)
 
 void sm_handle_state(acc_data_t *bmsdata)
 {
-	static uint8_t can_msg_to_send = 0;
+
 	enum {
 		ACC_STATUS,
 		CURRENT,

--- a/Core/Src/stateMachine.c
+++ b/Core/Src/stateMachine.c
@@ -182,11 +182,14 @@ void sm_handle_state(acc_data_t *bmsdata)
 	};
 
 	bmsdata->fault_code = sm_fault_return(bmsdata);
+	// compute_send_bms_status_message
 
 	// calculate_pwm(bmsdata);
 
 	if (bmsdata->fault_code != FAULTS_CLEAR) {
 		bmsdata->discharge_limit = 0;
+		// compute_send_mc_discharge_message
+		// compute_send_current_message
 		request_transition(FAULTED_STATE);
 	}
 	// TODO needs testing - (update, seems to work fine)
@@ -248,6 +251,7 @@ void request_transition(BMSState_t next_state)
 
 	init_LUT[next_state]();
 	current_state = next_state;
+	// compute_send_bms_status_message
 }
 
 uint32_t sm_fault_return(acc_data_t *accData)

--- a/Core/Src/stateMachine.c
+++ b/Core/Src/stateMachine.c
@@ -168,19 +168,6 @@ void handle_faulted(acc_data_t *bmsdata)
 void sm_handle_state(acc_data_t *bmsdata)
 {
 
-	enum {
-		ACC_STATUS,
-		CURRENT,
-		BMS_STATUS,
-		CELL_TEMP,
-		CELL_DATA,
-		SEGMENT_TEMP,
-		MC_DISCHARGE,
-		MC_CHARGE,
-		CAN_DEBUG,
-		MAX_MSGS
-	};
-
 	bmsdata->fault_code = sm_fault_return(bmsdata);
 
 	// calculate_pwm(bmsdata);
@@ -189,7 +176,7 @@ void sm_handle_state(acc_data_t *bmsdata)
 		bmsdata->discharge_limit = 0;
 		request_transition(FAULTED_STATE);
 	}
-	// TODO needs testing - (update, seems to work fine)
+	
 	handler_LUT[current_state](bmsdata);
 
 	bmsdata->is_charger_connected = compute_charger_connected();

--- a/Core/Src/stateMachine.c
+++ b/Core/Src/stateMachine.c
@@ -182,14 +182,11 @@ void sm_handle_state(acc_data_t *bmsdata)
 	};
 
 	bmsdata->fault_code = sm_fault_return(bmsdata);
-	// compute_send_bms_status_message
 
 	// calculate_pwm(bmsdata);
 
 	if (bmsdata->fault_code != FAULTS_CLEAR) {
 		bmsdata->discharge_limit = 0;
-		// compute_send_mc_discharge_message
-		// compute_send_current_message
 		request_transition(FAULTED_STATE);
 	}
 	// TODO needs testing - (update, seems to work fine)
@@ -199,47 +196,8 @@ void sm_handle_state(acc_data_t *bmsdata)
 
 	sm_broadcast_current_limit(bmsdata);
 
-	/* send relevant CAN msgs */
-	// clang-format off
-	if (is_timer_expired(&can_msg_timer) || !is_timer_active(&can_msg_timer))
-	{
-		switch (can_msg_to_send) {
-			case ACC_STATUS:
-				compute_send_acc_status_message(bmsdata);
-				break;
-			case CURRENT:
-				compute_send_current_message(bmsdata);
-				break;
-			case BMS_STATUS:
-				compute_send_bms_status_message(bmsdata, current_state, segment_is_balancing());
-				break;
-			case CELL_TEMP:
-				compute_send_cell_temp_message(bmsdata);
-				break;
-			case CELL_DATA:
-				compute_send_cell_data_message(bmsdata);
-				break;
-			case SEGMENT_TEMP:
-				compute_send_segment_temp_message(bmsdata);
-				break;
-			case MC_DISCHARGE:
-				compute_send_mc_discharge_message(bmsdata);
-				break;
-			case MC_CHARGE:
-				compute_send_mc_charge_message(bmsdata);
-				break;
-			
-			case CAN_DEBUG:
-				compute_send_debug_message(0,0, crc_error_check, 0);
-
-			default:
-				break;
-		}
-
-		start_timer(&can_msg_timer, CAN_MESSAGE_WAIT);
-		can_msg_to_send = (can_msg_to_send + 1) % MAX_MSGS;
-	}
-	// clang-format on
+	compute_send_bms_status_message(bmsdata, current_state,
+					segment_is_balancing());
 }
 
 void request_transition(BMSState_t next_state)
@@ -251,7 +209,6 @@ void request_transition(BMSState_t next_state)
 
 	init_LUT[next_state]();
 	current_state = next_state;
-	// compute_send_bms_status_message
 }
 
 uint32_t sm_fault_return(acc_data_t *accData)

--- a/Core/Src/stateMachine.c
+++ b/Core/Src/stateMachine.c
@@ -167,7 +167,6 @@ void handle_faulted(acc_data_t *bmsdata)
 
 void sm_handle_state(acc_data_t *bmsdata)
 {
-
 	bmsdata->fault_code = sm_fault_return(bmsdata);
 
 	// calculate_pwm(bmsdata);
@@ -176,7 +175,7 @@ void sm_handle_state(acc_data_t *bmsdata)
 		bmsdata->discharge_limit = 0;
 		request_transition(FAULTED_STATE);
 	}
-	
+
 	handler_LUT[current_state](bmsdata);
 
 	bmsdata->is_charger_connected = compute_charger_connected();


### PR DESCRIPTION
## Changes

Title plus some debugging and clean up. CAN messages are now sent once the values in them are updated. State machine is still messy. This PR sets up its fix by decoupling non-SM related things from the SM task.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)
- [x] Ligma

Closes #117 (issue #)
