### PR TITLE
CAN Rate Limiting Cleanup

### DIFF
--- a/Core/Inc/can_handler.h
+++ b/Core/Inc/can_handler.h
@@ -12,33 +12,46 @@
 #define NUM_INBOUND_CAN1_IDS 1
 #define NUM_INBOUND_CAN2_IDS 1
 
-#define CHARGE_CANID	    0x176
+#define CHARGE_CANID 0x176
+#define CHARGE_SIZE
 #define DISCHARGE_CANID	    0x156
+#define DISCHARGE_SIZE	    8
 #define ACC_STATUS_CANID    0x80
+#define ACC_STATUS_SIZE	    8
 #define BMS_STATUS_CANID    0x81
+#define BMS_STATUS_SIZE	    8
 #define SHUTDOWN_CTRL_CANID 0x82
+#define SHUTDOWN_CTRL_SIZE  1
 #define CELL_DATA_CANID	    0x83
+#define CELL_DATA_SIZE	    8
 #define CELL_VOLTAGE_CANID  0x87
+#define CELL_VOLTAGE_SIZE   8
 #define CURRENT_CANID	    0x86
+#define CURRENT_SIZE	    6
 #define CELL_TEMP_CANID	    0x84
+#define CELL_TEMP_SIZE	    8
 #define SEGMENT_TEMP_CANID  0x85
+#define SEGMENT_TEMP_SIZE   6
 #define FAULT_CANID	    0x703
+#define FAULT_SIZE	    6
 #define NOISE_CANID	    0x88
+#define NOISE_SIZE	    6
 #define DEBUG_CANID	    0x702
+#define DEBUG_SIZE 8
 
 /**
- * @brief Wrapper around can_msg_t that allows for rate limiting.
+ * @brief Datastructure for keeping track of the last time a CAN message was transmitted.
  * 
  */
 typedef struct {
-	can_msg_t msg;
+	uint32_t id;
 	uint32_t prev_tick;
 	uint32_t msg_rate; /* in milliseconds */
 } rl_can_msg_t;
 
 /* Implemented as a dynamically growing array */
 typedef struct {
-	rl_can_msg_t *bms_can_msgs;
+	rl_can_msg_t *msgs;
 	uint32_t num_elements;
 	uint32_t capacity;
 } rl_bms_msgs_t;

--- a/Core/Inc/can_handler.h
+++ b/Core/Inc/can_handler.h
@@ -26,27 +26,22 @@
 #define NOISE_CANID	    0x88
 #define DEBUG_CANID	    0x702
 
+/**
+ * @brief Wrapper around can_msg_t that allows for rate limiting.
+ * 
+ */
 typedef struct {
+	can_msg_t msg;
 	uint32_t prev_tick;
 	uint32_t msg_rate; /* in milliseconds */
-} rl_data_t;
+} rl_can_msg_t;
 
-typedef enum {
-	CHARGE,
-	DISCHARGE,
-	ACC_STATUS,
-	BMS_STATUS,
-	SHUTDOWN_CTRL,
-	CELL_DATA,
-	CELL_VOLTAGE,
-	CURRENT,
-	CELL_TEMP,
-	SEGMENT_TEMP,
-	FAULT,
-	NOISE,
-	DEBUG,
-	RL_MSG_COUNT
-} rate_lim_t;
+/* Implemented as a dynamically growing array */
+typedef struct {
+	rl_can_msg_t *bms_can_msgs;
+	uint32_t num_elements;
+	uint32_t capacity;
+} rl_bms_msgs_t;
 
 void can_receive_callback(CAN_HandleTypeDef *hcan);
 

--- a/Core/Inc/can_handler.h
+++ b/Core/Inc/can_handler.h
@@ -12,8 +12,8 @@
 #define NUM_INBOUND_CAN1_IDS 1
 #define NUM_INBOUND_CAN2_IDS 1
 
-#define CHARGE_CANID 0x176
-#define CHARGE_SIZE
+#define CHARGE_CANID	    0x176
+#define CHARGE_SIZE	    8
 #define DISCHARGE_CANID	    0x156
 #define DISCHARGE_SIZE	    8
 #define ACC_STATUS_CANID    0x80
@@ -37,7 +37,7 @@
 #define NOISE_CANID	    0x88
 #define NOISE_SIZE	    6
 #define DEBUG_CANID	    0x702
-#define DEBUG_SIZE 8
+#define DEBUG_SIZE	    8
 
 /**
  * @brief Datastructure for keeping track of the last time a CAN message was transmitted.

--- a/Core/Inc/can_handler.h
+++ b/Core/Inc/can_handler.h
@@ -39,23 +39,6 @@
 #define DEBUG_CANID	    0x702
 #define DEBUG_SIZE	    8
 
-/**
- * @brief Datastructure for keeping track of the last time a CAN message was transmitted.
- * 
- */
-typedef struct {
-	uint32_t id;
-	uint32_t prev_tick;
-	uint32_t msg_rate; /* in milliseconds */
-} rl_can_msg_t;
-
-/* Implemented as a dynamically growing array */
-typedef struct {
-	rl_can_msg_t *msgs;
-	uint32_t num_elements;
-	uint32_t capacity;
-} rl_bms_msgs_t;
-
 void can_receive_callback(CAN_HandleTypeDef *hcan);
 
 /**

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -67,6 +67,8 @@ void init_rl_can_msg(uint32_t id, uint32_t msg_rate)
 		rl_bms_msgs = malloc(sizeof(struct node_t));
 		rl_bms_msgs->val.id = id;
 		rl_bms_msgs->val.msg_rate = msg_rate;
+		rl_bms_msgs->val.prev_tick = HAL_GetTick();
+		rl_bms_msgs->next = NULL;
 		return;
 	}
 
@@ -76,11 +78,13 @@ void init_rl_can_msg(uint32_t id, uint32_t msg_rate)
 		curr = curr->next;
 	}
 
-	curr->next = malloc(sizeof(struct node_t));
-	curr = curr->next;
+	struct node_t *next = malloc(sizeof(struct node_t));
+	next->val.id = id;
+	next->val.msg_rate = msg_rate;
+	next->val.prev_tick = HAL_GetTick();
+	next->next = NULL;
 
-	curr->val.id = id;
-	curr->val.msg_rate = msg_rate;
+	curr->next = next;
 }
 
 /**
@@ -89,7 +93,9 @@ void init_rl_can_msg(uint32_t id, uint32_t msg_rate)
  */
 void init_can_msg_config()
 {
-	init_rl_can_msg(DISCHARGE_CANID, 5000);
+	init_rl_can_msg(DISCHARGE_CANID, 4000);
+	init_rl_can_msg(CHARGE_CANID, 3000);
+	init_rl_can_msg(BMS_STATUS_CANID, 7000);
 }
 
 void init_both_can(CAN_HandleTypeDef *hcan1, CAN_HandleTypeDef *hcan2)
@@ -161,8 +167,10 @@ int8_t queue_can_msg(can_msg_t msg)
 			    curr->val.prev_tick +
 				    pdMS_TO_TICKS(curr->val.msg_rate)) {
 				// block message
+				printf("Blocked 0x%lX\t", msg.id);
 				return 0;
 			} else {
+				printf("Sent 0x%lX\n", msg.id);
 				curr->val.prev_tick = HAL_GetTick();
 				break;
 			}

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -94,7 +94,7 @@ void init_rl_can_msg(uint32_t id, uint32_t msg_rate)
 void init_can_msg_config()
 {
 	// EXAMPLE
-	init_rl_can_msg(DISCHARGE_CANID, 4000);
+	// init_rl_can_msg(DISCHARGE_CANID, 4000);
 }
 
 void init_both_can(CAN_HandleTypeDef *hcan1, CAN_HandleTypeDef *hcan2)

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -16,7 +16,7 @@ static osMessageQueueId_t can_inbound_queue;
 can_t *can1;
 can_t *can2;
 
-struct rl_bms_msgs_t rl_bms_msgs;
+rl_bms_msgs_t rl_bms_msgs;
 
 static uint32_t can1_id_list[] = {
 	//CANID_X,
@@ -40,60 +40,43 @@ osStatus_t queue_and_set_flag(osMessageQueueId_t queue, const void *msg_ptr,
 	return status;
 }
 
-void init_can_msg(uint32_t id, uint8_t len)
-{
-	init_rl_can_msg(id, len, 0);
-}
-
-void init_rl_can_msg(uint32_t id, uint8_t len, uint32_t msg_rate)
+void init_rl_can_msg(uint32_t id, uint32_t msg_rate)
 {
 	if (rl_bms_msgs.num_elements == rl_bms_msgs.capacity) {
 		rl_can_msg_t *temp = (rl_can_msg_t *)malloc(
 			sizeof(rl_can_msg_t) * rl_bms_msgs.num_elements);
 
-		memcpy(temp, rl_bms_msgs.bms_can_msgs,
+		memcpy(temp, rl_bms_msgs.msgs,
 		       sizeof(rl_can_msg_t) * rl_bms_msgs.num_elements);
 
-		// do you even gotta do this if ur mallocing later
-		free(rl_bms_msgs.bms_can_msgs);
+		// do you even gotta do this if ur mallocing later?
+		free(rl_bms_msgs.msgs);
 
-		rl_bms_msgs.capacity *= 2;
-		rl_bms_msgs.bms_can_msgs =
+		rl_bms_msgs.capacity += 1;
+		rl_bms_msgs.msgs =
 			malloc(sizeof(rl_can_msg_t) * rl_bms_msgs.capacity);
 
-		memcpy(rl_bms_msgs.bms_can_msgs, temp,
+		memcpy(rl_bms_msgs.msgs, temp,
 		       sizeof(rl_can_msg_t) * rl_bms_msgs.num_elements);
 		free(temp);
 	}
-	rl_can_msg_t *msgptr =
-		&rl_bms_msgs.bms_can_msgs[rl_bms_msgs.num_elements];
-	msgptr->msg.id = id;
-	msgptr->msg.len = len;
+
+	rl_can_msg_t *msgptr = &rl_bms_msgs.msgs[rl_bms_msgs.num_elements];
+	msgptr->id = id;
 	msgptr->msg_rate = msg_rate;
+
+	rl_bms_msgs.num_elements += 1;
 }
 
 void init_can_msg_config()
 {
-	rl_bms_msgs.bms_can_msgs = (rl_can_msg_t *)malloc(sizeof(rl_can_msg_t));
+	rl_bms_msgs.msgs = (rl_can_msg_t *)malloc(sizeof(rl_can_msg_t));
 	rl_bms_msgs.capacity = 1;
 	rl_bms_msgs.num_elements = 0;
 
-	init_can_msg(DISCHARGE_CANID, 8);
-	init_can_msg(CHARGE_CANID, 8);
-	init_can_msg(ACC_STATUS_CANID, 8);
-	init_can_msg(BMS_STATUS_CANID, 8);
-	init_can_msg(SHUTDOWN_CTRL_CANID, 1);
-	init_can_msg(CELL_DATA_CANID, 8);
-	init_can_msg(CELL_VOLTAGE_CANID, 8);
-	init_can_msg(CURRENT_CANID, 6);
-	init_can_msg(CELL_TEMP_CANID, 8);
-	init_can_msg(SEGMENT_TEMP_CANID, 6);
-	init_can_msg(FAULT_CANID, 5);
-	init_can_msg(NOISE_CANID, 6);
-	init_can_msg(DEBUG_CANID, 8); // yaml decodes this to 8 bytes
-
+	// init_can_msg(DISCHARGE_CANID, 8);
 	// TODO: Test
-	init_rl_can_msg(DISCHARGE_CANID, 8, 5000);
+	init_rl_can_msg(DISCHARGE_CANID, 5000);
 }
 
 void init_both_can(CAN_HandleTypeDef *hcan1, CAN_HandleTypeDef *hcan2)
@@ -157,15 +140,17 @@ int8_t queue_can_msg(can_msg_t msg)
 	if (!can_outbound_queue)
 		return -1;
 
-	rl_data_t *rl_data = get_rl_msg(msg.id);
-
-	if (rl_data != NULL && rl_data->msg_rate != 0) {
-		if (HAL_GetTick() <=
-		    pdMS_TO_TICKS(rl_data->prev_tick) + rl_data->msg_rate) {
-			// block message
-			return 0;
-		} else {
-			rl_data->prev_tick = HAL_GetTick();
+	for (int i = 0; i < rl_bms_msgs.num_elements; i++) {
+		if (rl_bms_msgs.msgs[i].id == msg.id) {
+			if (HAL_GetTick() <=
+			    pdMS_TO_TICKS(rl_bms_msgs.msgs[i].prev_tick) +
+				    rl_bms_msgs.msgs[i].msg_rate) {
+				// block message
+				return 0;
+			} else {
+				rl_bms_msgs.msgs[i].prev_tick = HAL_GetTick();
+				break;
+			}
 		}
 	}
 

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -94,7 +94,7 @@ void init_rl_can_msg(uint32_t id, uint32_t msg_rate)
 void init_can_msg_config()
 {
 	// EXAMPLE
-	//init_rl_can_msg(DISCHARGE_CANID, 4000);
+	init_rl_can_msg(DISCHARGE_CANID, 4000);
 }
 
 void init_both_can(CAN_HandleTypeDef *hcan1, CAN_HandleTypeDef *hcan2)
@@ -166,10 +166,10 @@ int8_t queue_can_msg(can_msg_t msg)
 			    curr->val.prev_tick +
 				    pdMS_TO_TICKS(curr->val.msg_rate)) {
 				// block message
-				printf("Blocked 0x%lX\t", msg.id);
+				// printf("Blocked 0x%lX\t", msg.id);
 				return 0;
 			} else {
-				printf("Sent 0x%lX\n", msg.id);
+				// printf("Sent 0x%lX\n", msg.id);
 				curr->val.prev_tick = HAL_GetTick();
 				break;
 			}

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -74,8 +74,6 @@ void init_can_msg_config()
 	rl_bms_msgs.capacity = 1;
 	rl_bms_msgs.num_elements = 0;
 
-	// init_can_msg(DISCHARGE_CANID, 8);
-	// TODO: Test
 	init_rl_can_msg(DISCHARGE_CANID, 5000);
 }
 

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -13,10 +13,25 @@
 static osMessageQueueId_t can_outbound_queue;
 static osMessageQueueId_t can_inbound_queue;
 
+/**
+ * @brief Datastructure for keeping track of the last time a CAN message was transmitted.
+ * 
+ */
+typedef struct {
+	uint32_t id;
+	uint32_t prev_tick;
+	uint32_t msg_rate; /* in milliseconds */
+} rl_can_msg_t;
+
+struct node_t {
+	rl_can_msg_t val;
+	struct node_t *next;
+};
+
+struct node_t *rl_bms_msgs = NULL;
+
 can_t *can1;
 can_t *can2;
-
-rl_bms_msgs_t rl_bms_msgs;
 
 static uint32_t can1_id_list[] = {
 	//CANID_X,
@@ -40,40 +55,40 @@ osStatus_t queue_and_set_flag(osMessageQueueId_t queue, const void *msg_ptr,
 	return status;
 }
 
+/**
+ * @brief Add a CAN message to the list of rate limited CAN messages.
+ * 
+ * @param id ID of the CAN message to rate limit.
+ * @param msg_rate The amount of time that must pass before this CAN message can be ttansmitted again.
+ */
 void init_rl_can_msg(uint32_t id, uint32_t msg_rate)
 {
-	if (rl_bms_msgs.num_elements == rl_bms_msgs.capacity) {
-		rl_can_msg_t *temp = (rl_can_msg_t *)malloc(
-			sizeof(rl_can_msg_t) * rl_bms_msgs.num_elements);
-
-		memcpy(temp, rl_bms_msgs.msgs,
-		       sizeof(rl_can_msg_t) * rl_bms_msgs.num_elements);
-
-		// do you even gotta do this if ur mallocing later?
-		free(rl_bms_msgs.msgs);
-
-		rl_bms_msgs.capacity += 1;
-		rl_bms_msgs.msgs =
-			malloc(sizeof(rl_can_msg_t) * rl_bms_msgs.capacity);
-
-		memcpy(rl_bms_msgs.msgs, temp,
-		       sizeof(rl_can_msg_t) * rl_bms_msgs.num_elements);
-		free(temp);
+	if (rl_bms_msgs == NULL) {
+		rl_bms_msgs = malloc(sizeof(struct node_t));
+		rl_bms_msgs->val.id = id;
+		rl_bms_msgs->val.msg_rate = msg_rate;
+		return;
 	}
 
-	rl_can_msg_t *msgptr = &rl_bms_msgs.msgs[rl_bms_msgs.num_elements];
-	msgptr->id = id;
-	msgptr->msg_rate = msg_rate;
+	struct node_t *curr = rl_bms_msgs;
 
-	rl_bms_msgs.num_elements += 1;
+	while (curr->next != NULL) {
+		curr = curr->next;
+	}
+
+	curr->next = malloc(sizeof(struct node_t));
+	curr = curr->next;
+
+	curr->val.id = id;
+	curr->val.msg_rate = msg_rate;
 }
 
+/**
+ * @brief Initialize any per message configurations.
+ * 
+ */
 void init_can_msg_config()
 {
-	rl_bms_msgs.msgs = (rl_can_msg_t *)malloc(sizeof(rl_can_msg_t));
-	rl_bms_msgs.capacity = 1;
-	rl_bms_msgs.num_elements = 0;
-
 	init_rl_can_msg(DISCHARGE_CANID, 5000);
 }
 
@@ -138,18 +153,21 @@ int8_t queue_can_msg(can_msg_t msg)
 	if (!can_outbound_queue)
 		return -1;
 
-	for (int i = 0; i < rl_bms_msgs.num_elements; i++) {
-		if (rl_bms_msgs.msgs[i].id == msg.id) {
+	struct node_t *curr = rl_bms_msgs;
+
+	while (curr != NULL) {
+		if (curr->val.id == msg.id) {
 			if (HAL_GetTick() <=
-			    pdMS_TO_TICKS(rl_bms_msgs.msgs[i].prev_tick) +
-				    rl_bms_msgs.msgs[i].msg_rate) {
+			    pdMS_TO_TICKS(curr->val.prev_tick) +
+				    curr->val.msg_rate) {
 				// block message
 				return 0;
 			} else {
-				rl_bms_msgs.msgs[i].prev_tick = HAL_GetTick();
+				curr->val.prev_tick = HAL_GetTick();
 				break;
 			}
 		}
+		curr = curr->next;
 	}
 
 	return queue_and_set_flag(can_outbound_queue, &msg, can_dispatch_handle,

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -158,8 +158,8 @@ int8_t queue_can_msg(can_msg_t msg)
 	while (curr != NULL) {
 		if (curr->val.id == msg.id) {
 			if (HAL_GetTick() <=
-			    pdMS_TO_TICKS(curr->val.prev_tick) +
-				    curr->val.msg_rate) {
+			    curr->val.prev_tick +
+				    pdMS_TO_TICKS(curr->val.msg_rate)) {
 				// block message
 				return 0;
 			} else {

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define CAN_MSG_QUEUE_SIZE 50 /* messages */
 
@@ -15,8 +16,7 @@ static osMessageQueueId_t can_inbound_queue;
 can_t *can1;
 can_t *can2;
 
-can_msg_t bms_can_msgs[RL_MSG_COUNT];
-rl_data_t rl_data[RL_MSG_COUNT];
+struct rl_bms_msgs_t rl_bms_msgs;
 
 static uint32_t can1_id_list[] = {
 	//CANID_X,
@@ -40,130 +40,60 @@ osStatus_t queue_and_set_flag(osMessageQueueId_t queue, const void *msg_ptr,
 	return status;
 }
 
-void init_can_msg_config()
+void init_can_msg(uint32_t id, uint8_t len)
 {
-	can_msg_t discharge_msg = { 0 };
-	discharge_msg.id =
-		DISCHARGE_CANID; // 0x0A is the dcl id, 0x22 is the device id set by us
-	discharge_msg.len = 8;
-
-	can_msg_t charge_msg = { 0 };
-	charge_msg.id =
-		CHARGE_CANID; // 0x0A is the dcl id, 0x157 is the device id set by us
-	charge_msg.len = 8;
-
-	can_msg_t acc_status_msg;
-	acc_status_msg.id = ACC_STATUS_CANID;
-	acc_status_msg.len = 8;
-
-	can_msg_t bms_status_msg;
-	bms_status_msg.id = BMS_STATUS_CANID;
-	bms_status_msg.len = 8;
-
-	can_msg_t shutdown_ctrl_msg;
-	shutdown_ctrl_msg.id = SHUTDOWN_CTRL_CANID;
-	shutdown_ctrl_msg.len = 1;
-
-	can_msg_t cell_data_msg;
-	cell_data_msg.id = CELL_DATA_CANID;
-	cell_data_msg.len = 8;
-
-	can_msg_t cell_voltage_msg;
-	cell_voltage_msg.id = CELL_VOLTAGE_CANID;
-	cell_voltage_msg.len = 8;
-
-	can_msg_t current_msg;
-	current_msg.id = CURRENT_CANID;
-	current_msg.len = 6;
-
-	can_msg_t cell_temp_msg;
-	cell_temp_msg.id = CELL_TEMP_CANID;
-	cell_temp_msg.len = 8;
-
-	can_msg_t segment_temp_msg;
-	segment_temp_msg.id = SEGMENT_TEMP_CANID;
-	segment_temp_msg.len = 6;
-
-	can_msg_t fault_msg;
-	fault_msg.id = FAULT_CANID;
-	fault_msg.len = 5;
-
-	can_msg_t noise_msg;
-	noise_msg.id = NOISE_CANID;
-	noise_msg.len = 6;
-
-	can_msg_t debug_msg;
-	debug_msg.id = DEBUG_CANID;
-	debug_msg.len = 8; // yaml decodes this to 8 bytes
-
-	// rl_data_t rl_discharge_data = { .msg_rate = 5000 };
-	// rl_data_t rl_charge_data = { .msg_rate = 0 };
-
-	bms_can_msgs[DISCHARGE] = discharge_msg;
-	bms_can_msgs[CHARGE] = charge_msg;
-	bms_can_msgs[ACC_STATUS] = acc_status_msg;
-	bms_can_msgs[BMS_STATUS] = bms_status_msg;
-	bms_can_msgs[SHUTDOWN_CTRL] = shutdown_ctrl_msg;
-	bms_can_msgs[CELL_DATA] = cell_data_msg;
-	bms_can_msgs[CELL_VOLTAGE] = cell_voltage_msg;
-	bms_can_msgs[CURRENT] = current_msg;
-	bms_can_msgs[CELL_TEMP] = cell_temp_msg;
-	bms_can_msgs[SEGMENT_TEMP] = segment_temp_msg;
-	bms_can_msgs[FAULT] = fault_msg;
-	bms_can_msgs[NOISE] = noise_msg;
-	bms_can_msgs[DEBUG] = debug_msg;
-
-	// rl_data[DISCHARGE] = rl_discharge_data;
-	// rl_data[CHARGE] = rl_charge_data;
+	init_rl_can_msg(id, len, 0);
 }
 
-rl_data_t *get_rl_msg(uint32_t can_id)
+void init_rl_can_msg(uint32_t id, uint8_t len, uint32_t msg_rate)
 {
-	switch (can_id) {
-	case CHARGE_CANID:
-		return &rl_data[CHARGE];
-		break;
-	case DISCHARGE_CANID:
-		return &rl_data[DISCHARGE];
-		break;
-	case ACC_STATUS_CANID:
-		return &rl_data[ACC_STATUS];
-		break;
-	case BMS_STATUS_CANID:
-		return &rl_data[BMS_STATUS];
-		break;
-	case SHUTDOWN_CTRL_CANID:
-		return &rl_data[SHUTDOWN_CTRL];
-		break;
-	case CELL_DATA_CANID:
-		return &rl_data[CELL_DATA];
-		break;
-	case CELL_VOLTAGE_CANID:
-		return &rl_data[CELL_VOLTAGE];
-		break;
-	case CURRENT_CANID:
-		return &rl_data[CURRENT];
-		break;
-	case CELL_TEMP_CANID:
-		return &rl_data[CELL_TEMP];
-		break;
-	case SEGMENT_TEMP_CANID:
-		return &rl_data[SEGMENT_TEMP];
-		break;
-	case FAULT_CANID:
-		return &rl_data[FAULT];
-		break;
-	case NOISE_CANID:
-		return &rl_data[NOISE];
-		break;
-	case DEBUG_CANID:
-		return &rl_data[DEBUG];
-		break;
-	default:
-		break;
-	}
+	if (rl_bms_msgs.num_elements == rl_bms_msgs.capacity) {
+		rl_can_msg_t *temp = (rl_can_msg_t *)malloc(
+			sizeof(rl_can_msg_t) * rl_bms_msgs.num_elements);
 
-	return NULL;
+		memcpy(temp, rl_bms_msgs.bms_can_msgs,
+		       sizeof(rl_can_msg_t) * rl_bms_msgs.num_elements);
+
+		// do you even gotta do this if ur mallocing later
+		free(rl_bms_msgs.bms_can_msgs);
+
+		rl_bms_msgs.capacity *= 2;
+		rl_bms_msgs.bms_can_msgs =
+			malloc(sizeof(rl_can_msg_t) * rl_bms_msgs.capacity);
+
+		memcpy(rl_bms_msgs.bms_can_msgs, temp,
+		       sizeof(rl_can_msg_t) * rl_bms_msgs.num_elements);
+		free(temp);
+	}
+	rl_can_msg_t *msgptr =
+		&rl_bms_msgs.bms_can_msgs[rl_bms_msgs.num_elements];
+	msgptr->msg.id = id;
+	msgptr->msg.len = len;
+	msgptr->msg_rate = msg_rate;
+}
+
+void init_can_msg_config()
+{
+	rl_bms_msgs.bms_can_msgs = (rl_can_msg_t *)malloc(sizeof(rl_can_msg_t));
+	rl_bms_msgs.capacity = 1;
+	rl_bms_msgs.num_elements = 0;
+
+	init_can_msg(DISCHARGE_CANID, 8);
+	init_can_msg(CHARGE_CANID, 8);
+	init_can_msg(ACC_STATUS_CANID, 8);
+	init_can_msg(BMS_STATUS_CANID, 8);
+	init_can_msg(SHUTDOWN_CTRL_CANID, 1);
+	init_can_msg(CELL_DATA_CANID, 8);
+	init_can_msg(CELL_VOLTAGE_CANID, 8);
+	init_can_msg(CURRENT_CANID, 6);
+	init_can_msg(CELL_TEMP_CANID, 8);
+	init_can_msg(SEGMENT_TEMP_CANID, 6);
+	init_can_msg(FAULT_CANID, 5);
+	init_can_msg(NOISE_CANID, 6);
+	init_can_msg(DEBUG_CANID, 8); // yaml decodes this to 8 bytes
+
+	// TODO: Test
+	init_rl_can_msg(DISCHARGE_CANID, 8, 5000);
 }
 
 void init_both_can(CAN_HandleTypeDef *hcan1, CAN_HandleTypeDef *hcan2)

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -93,9 +93,8 @@ void init_rl_can_msg(uint32_t id, uint32_t msg_rate)
  */
 void init_can_msg_config()
 {
-	init_rl_can_msg(DISCHARGE_CANID, 4000);
-	init_rl_can_msg(CHARGE_CANID, 3000);
-	init_rl_can_msg(BMS_STATUS_CANID, 7000);
+	// EXAMPLE
+	//init_rl_can_msg(DISCHARGE_CANID, 4000);
 }
 
 void init_both_can(CAN_HandleTypeDef *hcan1, CAN_HandleTypeDef *hcan2)

--- a/Core/Src/compute.c
+++ b/Core/Src/compute.c
@@ -26,7 +26,11 @@ extern TIM_HandleTypeDef htim8;
 extern ADC_HandleTypeDef hadc1;
 extern ADC_HandleTypeDef hadc2;
 
-extern can_msg_t bms_can_msgs[RL_MSG_COUNT];
+extern rl_bms_msgs_t bms_can_msgs;
+
+// Array storing mapping of CAN message type to index in bms_can_msgs
+uint32_t *rl_bms_msgs_mapping;
+uint32_t rl_bms_msgs_size = 0;
 
 TIM_OC_InitTypeDef pwm_config;
 ADC_ChannelConfTypeDef adc_config;
@@ -40,6 +44,20 @@ uint32_t adc_values[2] = { 0 };
 float read_ref_voltage();
 float read_vout();
 void change_adc1_channel(uint8_t channel);
+
+void make_rl_can_mapping(uint32_t can_id)
+{
+	int i = 0;
+	while (i < bms_can_msgs.num_elements) {
+		if (bms_can_msgs.bms_can_msgs[i].msg.id == can_id) {
+			rl_bms_msgs_mapping[rl_bms_msgs_size] = i;
+			return;
+		}
+		i += 1;
+	}
+	// DEBUG
+	printf("You messed up\n");
+}
 
 uint8_t compute_init(acc_data_t *bmsdata)
 {
@@ -71,6 +89,23 @@ uint8_t compute_init(acc_data_t *bmsdata)
 	assert(!HAL_ADC_Start_DMA(&hadc2, &raw_high_current_buf,
 				  sizeof(raw_high_current_buf) /
 					  sizeof(uint32_t)));
+
+	rl_bms_msgs_mapping = (uint32_t *)malloc(sizeof(uint32_t) *
+						 bms_can_msgs.num_elements);
+
+	make_rl_can_mapping(CHARGE_CANID);
+	make_rl_can_mapping(DISCHARGE_CANID);
+	make_rl_can_mapping(ACC_STATUS_CANID);
+	make_rl_can_mapping(BMS_STATUS_CANID);
+	make_rl_can_mapping(SHUTDOWN_CTRL_CANID);
+	make_rl_can_mapping(CELL_DATA_CANID);
+	make_rl_can_mapping(CELL_VOLTAGE_CANID);
+	make_rl_can_mapping(CURRENT_CANID);
+	make_rl_can_mapping(CELL_TEMP_CANID);
+	make_rl_can_mapping(SEGMENT_TEMP_CANID);
+	make_rl_can_mapping(FAULT_CANID);
+	make_rl_can_mapping(NOISE_CANID);
+	make_rl_can_mapping(DEBUG_CANID);
 
 	return 0;
 }
@@ -269,10 +304,10 @@ void compute_send_mc_discharge_message(acc_data_t *bmsdata)
 	endian_swap(&discharge_data.max_discharge,
 		    sizeof(discharge_data.max_discharge));
 
-	memcpy(bms_can_msgs[DISCHARGE].data, &discharge_data,
-	       sizeof(discharge_data));
+	memcpy(bms_can_msgs.bms_can_msgs[rl_bms_msgs_mapping[1]].msg.data,
+	       &discharge_data, sizeof(discharge_data));
 
-	queue_can_msg(bms_can_msgs[DISCHARGE]);
+	queue_can_msg(bms_can_msgs.bms_can_msgs[rl_bms_msgs_mapping[1]].msg);
 }
 
 void compute_send_mc_charge_message(acc_data_t *bmsdata)

--- a/Core/Src/compute.c
+++ b/Core/Src/compute.c
@@ -26,12 +26,6 @@ extern TIM_HandleTypeDef htim8;
 extern ADC_HandleTypeDef hadc1;
 extern ADC_HandleTypeDef hadc2;
 
-extern rl_bms_msgs_t bms_can_msgs;
-
-// Array storing mapping of CAN message type to index in bms_can_msgs
-uint32_t *rl_bms_msgs_mapping;
-uint32_t rl_bms_msgs_size = 0;
-
 TIM_OC_InitTypeDef pwm_config;
 ADC_ChannelConfTypeDef adc_config;
 
@@ -44,20 +38,6 @@ uint32_t adc_values[2] = { 0 };
 float read_ref_voltage();
 float read_vout();
 void change_adc1_channel(uint8_t channel);
-
-void make_rl_can_mapping(uint32_t can_id)
-{
-	int i = 0;
-	while (i < bms_can_msgs.num_elements) {
-		if (bms_can_msgs.bms_can_msgs[i].msg.id == can_id) {
-			rl_bms_msgs_mapping[rl_bms_msgs_size] = i;
-			return;
-		}
-		i += 1;
-	}
-	// DEBUG
-	printf("You messed up\n");
-}
 
 uint8_t compute_init(acc_data_t *bmsdata)
 {
@@ -89,23 +69,6 @@ uint8_t compute_init(acc_data_t *bmsdata)
 	assert(!HAL_ADC_Start_DMA(&hadc2, &raw_high_current_buf,
 				  sizeof(raw_high_current_buf) /
 					  sizeof(uint32_t)));
-
-	rl_bms_msgs_mapping = (uint32_t *)malloc(sizeof(uint32_t) *
-						 bms_can_msgs.num_elements);
-
-	make_rl_can_mapping(CHARGE_CANID);
-	make_rl_can_mapping(DISCHARGE_CANID);
-	make_rl_can_mapping(ACC_STATUS_CANID);
-	make_rl_can_mapping(BMS_STATUS_CANID);
-	make_rl_can_mapping(SHUTDOWN_CTRL_CANID);
-	make_rl_can_mapping(CELL_DATA_CANID);
-	make_rl_can_mapping(CELL_VOLTAGE_CANID);
-	make_rl_can_mapping(CURRENT_CANID);
-	make_rl_can_mapping(CELL_TEMP_CANID);
-	make_rl_can_mapping(SEGMENT_TEMP_CANID);
-	make_rl_can_mapping(FAULT_CANID);
-	make_rl_can_mapping(NOISE_CANID);
-	make_rl_can_mapping(DEBUG_CANID);
 
 	return 0;
 }
@@ -304,10 +267,13 @@ void compute_send_mc_discharge_message(acc_data_t *bmsdata)
 	endian_swap(&discharge_data.max_discharge,
 		    sizeof(discharge_data.max_discharge));
 
-	memcpy(bms_can_msgs.bms_can_msgs[rl_bms_msgs_mapping[1]].msg.data,
-	       &discharge_data, sizeof(discharge_data));
+	can_msg_t msg;
+	msg.id = DISCHARGE_CANID;
+	msg.len = DISCHARGE_SIZE;
 
-	queue_can_msg(bms_can_msgs.bms_can_msgs[rl_bms_msgs_mapping[1]].msg);
+	memcpy(msg.data, &discharge_data, sizeof(discharge_data));
+
+	queue_can_msg(msg);
 }
 
 void compute_send_mc_charge_message(acc_data_t *bmsdata)
@@ -322,9 +288,13 @@ void compute_send_mc_charge_message(acc_data_t *bmsdata)
 	/* convert to big endian */
 	endian_swap(&charge_data.max_charge, sizeof(charge_data.max_charge));
 
-	memcpy(bms_can_msgs[CHARGE].data, &charge_data, sizeof(charge_data));
+	can_msg_t msg;
+	msg.id = CHARGE_CANID;
+	msg.len = CHARGE_SIZE;
 
-	queue_can_msg(bms_can_msgs[CHARGE]);
+	memcpy(msg.data, &charge_data, sizeof(charge_data));
+
+	queue_can_msg(msg);
 }
 
 void compute_send_acc_status_message(acc_data_t *bmsdata)
@@ -352,10 +322,13 @@ void compute_send_acc_status_message(acc_data_t *bmsdata)
 	endian_swap(&acc_status_msg_data.pack_ah,
 		    sizeof(acc_status_msg_data.pack_ah));
 
-	memcpy(bms_can_msgs[ACC_STATUS].data, &acc_status_msg_data,
-	       sizeof(acc_status_msg_data));
+	can_msg_t msg;
+	msg.id = ACC_STATUS_CANID;
+	msg.len = ACC_STATUS_SIZE;
 
-	queue_can_msg(bms_can_msgs[ACC_STATUS]);
+	memcpy(msg.data, &acc_status_msg_data, sizeof(acc_status_msg_data));
+
+	queue_can_msg(msg);
 }
 
 void compute_send_bms_status_message(acc_data_t *bmsdata, int bms_state,
@@ -380,10 +353,13 @@ void compute_send_bms_status_message(acc_data_t *bmsdata, int bms_state,
 	endian_swap(&bms_status_msg_data.fault,
 		    sizeof(bms_status_msg_data.fault));
 
-	memcpy(bms_can_msgs[BMS_STATUS].data, &bms_status_msg_data,
-	       sizeof(bms_status_msg_data));
+	can_msg_t msg;
+	msg.id = BMS_STATUS_CANID;
+	msg.len = BMS_STATUS_SIZE;
 
-	queue_can_msg(bms_can_msgs[BMS_STATUS]);
+	memcpy(msg.data, &bms_status_msg_data, sizeof(bms_status_msg_data));
+
+	queue_can_msg(msg);
 }
 
 void compute_send_shutdown_ctrl_message(uint8_t mpe_state)
@@ -394,10 +370,14 @@ void compute_send_shutdown_ctrl_message(uint8_t mpe_state)
 
 	shutdown_control_msg_data.mpeState = mpe_state;
 
-	memcpy(bms_can_msgs[SHUTDOWN_CTRL].data, &shutdown_control_msg_data,
+	can_msg_t msg;
+	msg.id = SHUTDOWN_CTRL_CANID;
+	msg.len = SHUTDOWN_CTRL_SIZE;
+
+	memcpy(msg.data, &shutdown_control_msg_data,
 	       sizeof(shutdown_control_msg_data));
 
-	queue_can_msg(bms_can_msgs[SHUTDOWN_CTRL]);
+	queue_can_msg(msg);
 }
 
 void compute_send_cell_data_message(acc_data_t *bmsdata)
@@ -427,10 +407,13 @@ void compute_send_cell_data_message(acc_data_t *bmsdata)
 	endian_swap(&cell_data_msg_data.volt_avg,
 		    sizeof(cell_data_msg_data.volt_avg));
 
-	memcpy(bms_can_msgs[CELL_DATA].data, &cell_data_msg_data,
-	       sizeof(cell_data_msg_data));
+	can_msg_t msg;
+	msg.id = CELL_DATA_CANID;
+	msg.len = CELL_DATA_SIZE;
 
-	queue_can_msg(bms_can_msgs[CELL_DATA]);
+	memcpy(msg.data, &cell_data_msg_data, sizeof(cell_data_msg_data));
+
+	queue_can_msg(msg);
 }
 
 void compute_send_cell_voltage_message(uint8_t cell_id,
@@ -460,10 +443,13 @@ void compute_send_cell_voltage_message(uint8_t cell_id,
 	endian_swap(&cell_voltage_msg_data.openVoltage,
 		    sizeof(cell_voltage_msg_data.openVoltage));
 
-	memcpy(bms_can_msgs[CELL_VOLTAGE].data, &cell_voltage_msg_data,
-	       sizeof(cell_voltage_msg_data));
+	can_msg_t msg;
+	msg.id = CELL_VOLTAGE_CANID;
+	msg.len = CELL_VOLTAGE_SIZE;
 
-	queue_can_msg(bms_can_msgs[CELL_VOLTAGE]);
+	memcpy(msg.data, &cell_voltage_msg_data, sizeof(cell_voltage_msg_data));
+
+	queue_can_msg(msg);
 }
 
 void compute_send_current_message(acc_data_t *bmsdata)
@@ -486,10 +472,14 @@ void compute_send_current_message(acc_data_t *bmsdata)
 	endian_swap(&current_status_msg_data.pack_curr,
 		    sizeof(current_status_msg_data.pack_curr));
 
-	memcpy(bms_can_msgs[CURRENT].data, &current_status_msg_data,
+	can_msg_t msg;
+	msg.id = CURRENT_CANID;
+	msg.len = CURRENT_SIZE;
+
+	memcpy(msg.data, &current_status_msg_data,
 	       sizeof(current_status_msg_data));
 
-	queue_can_msg(bms_can_msgs[CURRENT]);
+	queue_can_msg(msg);
 }
 
 void compute_send_cell_temp_message(acc_data_t *bmsdata)
@@ -518,10 +508,13 @@ void compute_send_cell_temp_message(acc_data_t *bmsdata)
 	endian_swap(&cell_temp_msg_data.average_temp,
 		    sizeof(cell_temp_msg_data.average_temp));
 
-	memcpy(bms_can_msgs[CELL_TEMP].data, &cell_temp_msg_data,
-	       sizeof(cell_temp_msg_data));
+	can_msg_t msg;
+	msg.id = CELL_TEMP_CANID;
+	msg.len = CELL_TEMP_SIZE;
 
-	queue_can_msg(bms_can_msgs[CELL_TEMP]);
+	memcpy(msg.data, &cell_temp_msg_data, sizeof(cell_temp_msg_data));
+
+	queue_can_msg(msg);
 }
 
 void compute_send_segment_temp_message(acc_data_t *bmsdata)
@@ -549,10 +542,13 @@ void compute_send_segment_temp_message(acc_data_t *bmsdata)
 	segment_temp_msg_data.segment6_average_temp =
 		bmsdata->segment_average_temps[5];
 
-	memcpy(bms_can_msgs[SEGMENT_TEMP].data, &segment_temp_msg_data,
-	       sizeof(segment_temp_msg_data));
+	can_msg_t msg;
+	msg.id = SEGMENT_TEMP_CANID;
+	msg.len = SEGMENT_TEMP_SIZE;
 
-	queue_can_msg(bms_can_msgs[SEGMENT_TEMP]);
+	memcpy(msg.data, &segment_temp_msg_data, sizeof(segment_temp_msg_data));
+
+	queue_can_msg(msg);
 }
 
 void compute_send_fault_message(uint8_t status, int16_t curr, int16_t in_dcl)
@@ -571,10 +567,13 @@ void compute_send_fault_message(uint8_t status, int16_t curr, int16_t in_dcl)
 		    sizeof(fault_msg_data.pack_curr));
 	endian_swap(&fault_msg_data.dcl, sizeof(fault_msg_data.dcl));
 
-	memcpy(bms_can_msgs[FAULT].data, &fault_msg_data,
-	       sizeof(fault_msg_data));
+	can_msg_t msg;
+	msg.id = FAULT_CANID;
+	msg.len = FAULT_SIZE;
 
-	queue_can_msg(bms_can_msgs[FAULT]);
+	memcpy(msg.data, &fault_msg_data, sizeof(fault_msg_data));
+
+	queue_can_msg(msg);
 }
 
 void compute_send_voltage_noise_message(acc_data_t *bmsdata)
@@ -601,10 +600,14 @@ void compute_send_voltage_noise_message(acc_data_t *bmsdata)
 	voltage_noise_msg_data.seg6_noise =
 		bmsdata->segment_noise_percentage[5];
 
-	memcpy(bms_can_msgs[NOISE].data, &voltage_noise_msg_data,
+	can_msg_t msg;
+	msg.id = NOISE_CANID;
+	msg.len = NOISE_SIZE;
+
+	memcpy(msg.data, &voltage_noise_msg_data,
 	       sizeof(voltage_noise_msg_data));
 
-	queue_can_msg(bms_can_msgs[NOISE]);
+	queue_can_msg(msg);
 }
 
 void compute_send_debug_message(uint8_t debug0, uint8_t debug1, uint16_t debug2,
@@ -625,9 +628,13 @@ void compute_send_debug_message(uint8_t debug0, uint8_t debug1, uint16_t debug2,
 	endian_swap(&debug_msg_data.debug2, sizeof(debug_msg_data.debug2));
 	endian_swap(&debug_msg_data.debug3, sizeof(debug_msg_data.debug3));
 
-	memcpy(bms_can_msgs[DEBUG].data, &debug_msg_data, 8);
+	can_msg_t msg;
+	msg.id = DEBUG_CANID;
+	msg.len = DEBUG_SIZE;
 
-	queue_can_msg(bms_can_msgs[DEBUG]);
+	memcpy(msg.data, &debug_msg_data, 8);
+
+	queue_can_msg(msg);
 }
 
 void change_adc1_channel(uint8_t channel)


### PR DESCRIPTION
## Changes

The previous CAN rate limiting setup required developers to change things in three different places when adding a new CAN message, even if they did not want to rate limit it. In this new setup, a developer does not have to do anything extra when adding a new CAN message, however if they want to, they can easily set a rate limit for a CAN message by only adding one extra function call in the can config init function.

## Test Cases

- [x] Test on hardware

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
