### PR TITLE
 Implement Cell Data Logging with Timestamping

### DIFF
--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -31,15 +31,12 @@
  * This structure is used to store the timestamp, cell voltages, 
  * and cell temperatures for each measurement cycle. Each entry 
  * contains data for all chips and their respective cells.
- * 
- * @note If used across multiple tasks, the user must handle the mutex. 
  */
 typedef struct {
 	uint32_t cell_voltage_timestamp;
 	uint32_t cell_temperature_timestamp;
 	float cell_voltages[NUM_CHIPS][NUM_CELLS_ALPHA];
 	float cell_temperatures[NUM_CHIPS][NUM_CELLS_ALPHA];
-	osMutexId_t mutex;
 } CellDataEntry_t;
 
 /**

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -1,6 +1,14 @@
 /**
  * @file cell_data_logging.h
  * @brief Functionality for logging and retrieving cell voltage and temperature data.
+ *
+ * This module provides an interface for logging cell voltage and temperature
+ * data using a ring buffer. Users must ensure proper synchronization when
+ * handling logging operations, as well as setting timestamps before logging.
+ *
+ * @warning The `BMSLogger` structure is *managed internally by the logging system. 
+ * Users should *only pass its address to logging functions and must not modify 
+ * its contents directly.
  */
 
 #ifndef CELL_DATA_LOGGING_H
@@ -23,29 +31,30 @@
  * This structure is used to store the timestamp, cell voltages, 
  * and cell temperatures for each measurement cycle. Each entry 
  * contains data for all chips and their respective cells.
+ * 
+ * @note If used across multiple tasks, the user must handle the mutex. 
  */
 typedef struct {
 	uint32_t cell_voltage_timestamp;
 	uint32_t cell_temperature_timestamp;
 	float cell_voltages[NUM_CHIPS][NUM_CELLS_ALPHA];
 	float cell_temperatures[NUM_CHIPS][NUM_CELLS_ALPHA];
+	osMutexId_t mutex;
 } CellDataEntry_t;
 
 /**
  * @struct BMSLogger
  * @brief Structure to manage logging system
+ * 
+ * @warning The `BMSLogger` structure is *managed internally by the logging system. 
+ * Users should *only pass its address to logging functions and must not modify 
+ * its contents directly.
  */
 struct BMSLogger {
 	ringbuf_t ring_buff;
 	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
 	osMutexId_t mutex;
 };
-
-/**
- * @brief Retrieves the current timestamp in microseconds from TIM2.
- * @return The current timestamp in microseconds.
- */
-uint32_t get_us_timestamp(void);
 
 /**
  * @brief Initializes a BMSLogger instance.
@@ -55,12 +64,29 @@ uint32_t get_us_timestamp(void);
 int cell_data_logger_init(struct BMSLogger *logger);
 
 /**
- * @brief Logs a new measurement and inserts it in the ring buffer.
- * @param logger Pointer to the logger instance.
- * @param bms_data Pointer to the BMS data containing chip cell voltages and temperatures.
+ * @brief Assigns a timestamp to the voltage measurement field of a cell data entry.
+ * @param entry Pointer to the CellDataEntry_t structure to update.
+ */
+void cell_data_set_voltage_timestamp(CellDataEntry_t *entry);
+
+/**
+  * @brief Assigns a timestamp to the temperature measurement field of a cell data entry.
+  * @param entry Pointer to the CellDataEntry_t structure to update.
+  */
+void cell_data_set_therm_timestamp(CellDataEntry_t *entry);
+
+/**
+ * @brief Logs a new measurement and inserts it into the ring buffer.
+ * 
+ * @note The user is responsible for ensuring the timestamps are set before calling this function.
+ * 
+ * @param logger Pointer to the BMSLogger instance managing the ring buffer.
+ * @param bms_data Pointer to the BMS data structure containing cell voltages and temperatures.
+ * @param entry Pointer to a CellDataEntry_t structure that holds the measurement data.
  * @return 0 on success, -1 on failure.
  */
-int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data);
+int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data,
+			      CellDataEntry_t *entry);
 
 /**
  * @brief Gets the most recent cell data log from the buffer.

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -50,6 +50,8 @@ typedef struct {
 struct BMSLogger {
 	ringbuf_t ring_buff;
 	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
+	CellDataEntry_t *latest_entry;
+	bool first_timestamp_set;
 	osMutexId_t mutex;
 };
 
@@ -61,16 +63,18 @@ struct BMSLogger {
 int cell_data_logger_init(struct BMSLogger *logger);
 
 /**
- * @brief Assigns a timestamp to the voltage measurement field of a cell data entry.
- * @param entry Pointer to the CellDataEntry_t structure to update.
+ * @brief Assigns a voltage timestamp to the current log entry. 
+ * @param logger Pointer to the BMSLogger instance.
+ * @return 0 on success, -1 on failure.
  */
-void cell_data_set_voltage_timestamp(CellDataEntry_t *entry);
+int cell_data_logger_timestamp_voltage(struct BMSLogger *logger);
 
 /**
-  * @brief Assigns a timestamp to the temperature measurement field of a cell data entry.
-  * @param entry Pointer to the CellDataEntry_t structure to update.
-  */
-void cell_data_set_therm_timestamp(CellDataEntry_t *entry);
+ * @brief Assigns a temperature timestamp to the current log entry.
+ * @param logger Pointer to the BMSLogger instance.
+ * @return 0 on success, -1 on failure.
+ */
+int cell_data_logger_timestamp_therms(struct BMSLogger *logger);
 
 /**
  * @brief Logs a new measurement and inserts it into the ring buffer.
@@ -79,11 +83,9 @@ void cell_data_set_therm_timestamp(CellDataEntry_t *entry);
  * 
  * @param logger Pointer to the BMSLogger instance managing the ring buffer.
  * @param bms_data Pointer to the BMS data structure containing cell voltages and temperatures.
- * @param entry Pointer to a CellDataEntry_t structure that holds the measurement data.
  * @return 0 on success, -1 on failure.
  */
-int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data,
-			      CellDataEntry_t *entry);
+int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data);
 
 /**
  * @brief Gets the most recent cell data log from the buffer.

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -8,7 +8,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include "bmsConfig.h"
+#include <stdbool.h>
 #include "datastructs.h"
 #include "ringbuffer.h"
 
@@ -30,38 +30,57 @@ typedef struct {
 } CellDataEntry_t;
 
 /**
-  * @brief Sets up the ring buffer for cell data logging.
-  */
-void cell_data_logger_init(void);
+ * @struct BMSLogger
+ * @brief Structure to manage logging system
+ */
+typedef struct {
+	ringbuf_t ring_buff;
+	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
+} BMSLogger;
 
 /**
-  * @brief Logs a new measurement and inserts it in the ring buffer.
-  * @param bms_data Pointer to the BMS data containing chip cell voltages and temperatures.
-  */
-void cell_data_log_measurement(acc_data_t *bms_data);
+ * @brief Initializes a BMSLogger instance.
+ * @param logger Pointer to the logger instance.
+ * @return false on success, true on failure.
+ */
+bool cell_data_logger_init(BMSLogger *logger);
 
 /**
-  * @brief Gets the most recent cell data log from the buffer.
-  * @return Pointer to the most recent CellDataEntry_t data.
-  */
-CellDataEntry_t *cell_data_log_get_last(void);
+ * @brief Logs a new measurement and inserts it in the ring buffer.
+ * @param logger Pointer to the logger instance.
+ * @param bms_data Pointer to the BMS data containing chip cell voltages and temperatures.
+ * @return false on success, true on failure.
+ */
+bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data);
 
 /**
-  * @brief Retrieves the last n cell data logs from the buffer.
-  * @param n Number of previous cell data logs to retrieve.
-  * @param out_buffer Pointer to the buffer where the readings will be stored.
-  */
-void cell_data_log_get_last_n(size_t n, CellDataEntry_t *out_buffer);
+ * @brief Gets the most recent cell data log from the buffer.
+ * @param logger Pointer to the logger instance.
+ * @return Pointer to the most recent data entry, or NULL if the logger is empty.
+ */
+CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger);
 
 /**
-  * @brief Serial prints the most recent data log.
-  */
-void print_latest_cell_data_log(void);
+ * @brief Retrieves the last n cell data logs from the buffer.
+ * @param logger Pointer to the logger instance.
+ * @param n Number of previous logs to retrieve.
+ * @param out_buffer Pointer to the buffer where the readings will be stored.
+ * @return false on success, true on failure.
+ */
+bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
+			      CellDataEntry_t *out_buffer);
 
 /**
-  * @brief Serial prints the last n cell data logs.
-  * @param n Number of previous cell data logs to retrieve to print.
-  */
-void print_last_n_cell_data_logs(size_t n);
+ * @brief Serial prints the most recent data log.
+ * @param logger Pointer to the logger instance.
+ */
+void print_latest_cell_data_log(const BMSLogger *logger);
+
+/**
+ * @brief Serial prints the last n cell data logs.
+ * @param logger Pointer to the logger instance.
+ * @param n Number of previous logs to print.
+ */
+void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n);
 
 #endif

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -33,10 +33,13 @@ typedef struct {
  * @struct BMSLogger
  * @brief Structure to manage logging system
  */
-typedef struct {
-	ringbuf_t ring_buff;
-	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
-} BMSLogger;
+typedef struct BMSLogger BMSLogger;
+
+/**
+ * @brief Retrieves the global instance of the BMSLogger.
+ * @return Pointer to the global `BMSLogger` instance.
+ */
+BMSLogger *getLogger(void);
 
 /**
  * @brief Initializes a BMSLogger instance.

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -50,8 +50,6 @@ typedef struct {
 struct BMSLogger {
 	ringbuf_t ring_buff;
 	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
-	CellDataEntry_t *latest_entry;
-	bool first_timestamp_set;
 	osMutexId_t mutex;
 };
 
@@ -63,7 +61,7 @@ struct BMSLogger {
 int cell_data_logger_init(struct BMSLogger *logger);
 
 /**
- * @brief Assigns a voltage timestamp to the current log entry. 
+ * @brief Assigns a voltage timestamp to the current log entry.
  * @param logger Pointer to the BMSLogger instance.
  * @return 0 on success, -1 on failure.
  */
@@ -79,20 +77,13 @@ int cell_data_logger_timestamp_therms(struct BMSLogger *logger);
 /**
  * @brief Logs a new measurement and inserts it into the ring buffer.
  * 
- * @note The user is responsible for ensuring the timestamps are set before calling this function.
+ * @note The user must ensure timestamps are set before calling this function.
  * 
  * @param logger Pointer to the BMSLogger instance managing the ring buffer.
  * @param bms_data Pointer to the BMS data structure containing cell voltages and temperatures.
  * @return 0 on success, -1 on failure.
  */
 int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data);
-
-/**
- * @brief Gets the most recent cell data log from the buffer.
- * @param logger Pointer to the logger instance.
- * @return Pointer to the most recent data entry, or NULL if the logger is empty.
- */
-CellDataEntry_t *cell_data_log_get_last(const struct BMSLogger *logger);
 
 /**
  * @brief Retrieves the last n cell data logs from the buffer.

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -16,9 +16,6 @@
 // Number of stored cell data readings in ring buffer.
 #define NUM_OF_READINGS 10
 
-// Logger mutex wait time in milliseconds
-#define LOGGER_MUTEX_WAIT_TIME 10
-
 /**
  * @struct CellDataEntry_t
  * @brief Structure to store logged cell voltage and temperature data.

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -41,12 +41,6 @@ typedef struct {
 typedef struct BMSLogger BMSLogger;
 
 /**
- * @brief Retrieves the global instance of the BMSLogger.
- * @return Pointer to the global `BMSLogger` instance.
- */
-BMSLogger *get_logger(void);
-
-/**
  * @brief Retrieves the current timestamp in microseconds from TIM2;
  * @return The current timestamp in microseconds.
  */

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -24,7 +24,8 @@
  * contains data for all chips and their respective cells.
  */
 typedef struct {
-	uint32_t timestamp[NUM_CHIPS][NUM_CELLS_ALPHA];
+	uint32_t cell_voltage_timestamp;
+	uint32_t cell_temperature_timestamp;
 	float cell_voltages[NUM_CHIPS][NUM_CELLS_ALPHA];
 	float cell_temperatures[NUM_CHIPS][NUM_CELLS_ALPHA];
 } CellDataEntry_t;
@@ -40,6 +41,12 @@ typedef struct BMSLogger BMSLogger;
  * @return Pointer to the global `BMSLogger` instance.
  */
 BMSLogger *getLogger(void);
+
+/**
+ * @brief Retrieves the current timestamp in microseconds from TIM2;
+ * @return The current timestamp in microseconds.
+ */
+uint32_t get_us_timestamp(void);
 
 /**
  * @brief Initializes a BMSLogger instance.

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -38,16 +38,16 @@ typedef struct {
 struct BMSLogger;
 
 /**
- * @brief Retrieves the global instance of the BMSLogger.
- * @return Pointer to the global `BMSLogger` instance.
- */
-struct BMSLogger *get_logger(void);
-
-/**
  * @brief Retrieves the current timestamp in microseconds from TIM2.
  * @return The current timestamp in microseconds.
  */
 uint32_t get_us_timestamp(void);
+
+/**
+ * @brief Retrieves the global instance of the BMSLogger.
+ * @return Pointer to the global `BMSLogger` instance.
+ */
+struct BMSLogger *get_logger(void);
 
 /**
  * @brief Initializes a BMSLogger instance.

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -35,7 +35,13 @@ typedef struct {
  * @struct BMSLogger
  * @brief Structure to manage logging system
  */
-typedef struct BMSLogger BMSLogger;
+struct BMSLogger;
+
+/**
+ * @brief Retrieves the global instance of the BMSLogger.
+ * @return Pointer to the global `BMSLogger` instance.
+ */
+struct BMSLogger *get_logger(void);
 
 /**
  * @brief Retrieves the current timestamp in microseconds from TIM2.
@@ -48,7 +54,7 @@ uint32_t get_us_timestamp(void);
  * @param logger Pointer to the logger instance.
  * @return 0 on success, -1 on failure.
  */
-int cell_data_logger_init(BMSLogger *logger);
+int cell_data_logger_init(struct BMSLogger *logger);
 
 /**
  * @brief Logs a new measurement and inserts it in the ring buffer.
@@ -56,14 +62,14 @@ int cell_data_logger_init(BMSLogger *logger);
  * @param bms_data Pointer to the BMS data containing chip cell voltages and temperatures.
  * @return 0 on success, -1 on failure.
  */
-int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data);
+int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data);
 
 /**
  * @brief Gets the most recent cell data log from the buffer.
  * @param logger Pointer to the logger instance.
  * @return Pointer to the most recent data entry, or NULL if the logger is empty.
  */
-CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger);
+CellDataEntry_t *cell_data_log_get_last(const struct BMSLogger *logger);
 
 /**
  * @brief Retrieves the last n cell data logs from the buffer.
@@ -72,7 +78,7 @@ CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger);
  * @param out_buffer Pointer to the buffer where the readings will be stored.
  * @return 0 on success, -1 on failure.
  */
-int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
+int cell_data_log_get_last_n(const struct BMSLogger *logger, size_t n,
 			     CellDataEntry_t *out_buffer);
 
 /**
@@ -81,6 +87,6 @@ int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
  * @param n Number of previous logs to print.
  * @return 0 on success, -1 on failure.
  */
-int print_last_n_cell_data_logs(const BMSLogger *logger, size_t n);
+int print_last_n_cell_data_logs(const struct BMSLogger *logger, size_t n);
 
 #endif

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -51,7 +51,7 @@ uint32_t get_us_timestamp(void);
  * @param logger Pointer to the logger instance.
  * @return false on success, true on failure.
  */
-bool cell_data_logger_init(BMSLogger *logger);
+int cell_data_logger_init(BMSLogger *logger);
 
 /**
  * @brief Logs a new measurement and inserts it in the ring buffer.
@@ -59,7 +59,7 @@ bool cell_data_logger_init(BMSLogger *logger);
  * @param bms_data Pointer to the BMS data containing chip cell voltages and temperatures.
  * @return false on success, true on failure.
  */
-bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data);
+int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data);
 
 /**
  * @brief Gets the most recent cell data log from the buffer.
@@ -75,8 +75,8 @@ CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger);
  * @param out_buffer Pointer to the buffer where the readings will be stored.
  * @return false on success, true on failure.
  */
-bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
-			      CellDataEntry_t *out_buffer);
+int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
+			     CellDataEntry_t *out_buffer);
 
 /**
  * @brief Serial prints the most recent data log.

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -35,19 +35,17 @@ typedef struct {
  * @struct BMSLogger
  * @brief Structure to manage logging system
  */
-struct BMSLogger;
+struct BMSLogger {
+	ringbuf_t ring_buff;
+	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
+	osMutexId_t mutex;
+};
 
 /**
  * @brief Retrieves the current timestamp in microseconds from TIM2.
  * @return The current timestamp in microseconds.
  */
 uint32_t get_us_timestamp(void);
-
-/**
- * @brief Retrieves the global instance of the BMSLogger.
- * @return Pointer to the global `BMSLogger` instance.
- */
-struct BMSLogger *get_logger(void);
 
 /**
  * @brief Initializes a BMSLogger instance.

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -1,0 +1,67 @@
+/**
+ * @file cell_data_logging.h
+ * @brief Functionality for logging and retrieving cell voltage and temperature data.
+ */
+
+#ifndef CELL_DATA_LOGGING_H
+#define CELL_DATA_LOGGING_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "bmsConfig.h"
+#include "datastructs.h"
+#include "ringbuffer.h"
+
+// Number of stored cell data readings in ring buffer.
+#define NUM_OF_READINGS 10
+
+/**
+ * @struct CellDataEntry_t
+ * @brief Structure to store logged cell voltage and temperature data.
+ *
+ * This structure is used to store the timestamp, cell voltages, 
+ * and cell temperatures for each measurement cycle. Each entry 
+ * contains data for all chips and their respective cells.
+ */
+typedef struct {
+	uint32_t timestamp[NUM_CHIPS][NUM_CELLS_ALPHA];
+	float cell_voltages[NUM_CHIPS][NUM_CELLS_ALPHA];
+	float cell_temperatures[NUM_CHIPS][NUM_CELLS_ALPHA];
+} CellDataEntry_t;
+
+/**
+  * @brief Sets up the ring buffer for cell data logging.
+  */
+void cell_data_logger_init(void);
+
+/**
+  * @brief Logs a new measurement and inserts it in the ring buffer.
+  * @param bms_data Pointer to the BMS data containing chip cell voltages and temperatures.
+  */
+void cell_data_log_measurement(acc_data_t *bms_data);
+
+/**
+  * @brief Gets the most recent cell data log from the buffer.
+  * @return Pointer to the most recent CellDataEntry_t data.
+  */
+CellDataEntry_t *cell_data_log_get_last(void);
+
+/**
+  * @brief Retrieves the last n cell data logs from the buffer.
+  * @param n Number of previous cell data logs to retrieve.
+  * @param out_buffer Pointer to the buffer where the readings will be stored.
+  */
+void cell_data_log_get_last_n(size_t n, CellDataEntry_t *out_buffer);
+
+/**
+  * @brief Serial prints the most recent data log.
+  */
+void print_latest_cell_data_log(void);
+
+/**
+  * @brief Serial prints the last n cell data logs.
+  * @param n Number of previous cell data logs to retrieve to print.
+  */
+void print_last_n_cell_data_logs(size_t n);
+
+#endif

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -19,10 +19,6 @@
 // Logger mutex wait time in milliseconds
 #define LOGGER_MUTEX_WAIT_TIME 10
 
-// Convert the wait time from milliseconds to RTOS ticks
-#define LOGGER_MUTEX_WAIT_TICKS \
-	(LOGGER_MUTEX_WAIT_TIME * osKernelGetTickFreq() / 1000)
-
 /**
  * @struct CellDataEntry_t
  * @brief Structure to store logged cell voltage and temperature data.

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -79,16 +79,10 @@ int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 			     CellDataEntry_t *out_buffer);
 
 /**
- * @brief Serial prints the most recent data log.
- * @param logger Pointer to the logger instance.
- */
-void print_latest_cell_data_log(const BMSLogger *logger);
-
-/**
  * @brief Serial prints the last n cell data logs.
  * @param logger Pointer to the logger instance.
  * @param n Number of previous logs to print.
  */
-void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n);
+int print_last_n_cell_data_logs(const BMSLogger *logger, size_t n);
 
 #endif

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -11,9 +11,17 @@
 #include <stdbool.h>
 #include "datastructs.h"
 #include "ringbuffer.h"
+#include "cmsis_os.h"
 
 // Number of stored cell data readings in ring buffer.
 #define NUM_OF_READINGS 10
+
+// Logger mutex wait time in milliseconds
+#define LOGGER_MUTEX_WAIT_TIME 10
+
+// Convert the wait time from milliseconds to RTOS ticks
+#define LOGGER_MUTEX_WAIT_TICKS \
+	(LOGGER_MUTEX_WAIT_TIME * osKernelGetTickFreq() / 1000)
 
 /**
  * @struct CellDataEntry_t
@@ -40,7 +48,7 @@ typedef struct BMSLogger BMSLogger;
  * @brief Retrieves the global instance of the BMSLogger.
  * @return Pointer to the global `BMSLogger` instance.
  */
-BMSLogger *getLogger(void);
+BMSLogger *get_logger(void);
 
 /**
  * @brief Retrieves the current timestamp in microseconds from TIM2;

--- a/Core/Inc/cell_data_logging.h
+++ b/Core/Inc/cell_data_logging.h
@@ -38,7 +38,7 @@ typedef struct {
 typedef struct BMSLogger BMSLogger;
 
 /**
- * @brief Retrieves the current timestamp in microseconds from TIM2;
+ * @brief Retrieves the current timestamp in microseconds from TIM2.
  * @return The current timestamp in microseconds.
  */
 uint32_t get_us_timestamp(void);
@@ -46,7 +46,7 @@ uint32_t get_us_timestamp(void);
 /**
  * @brief Initializes a BMSLogger instance.
  * @param logger Pointer to the logger instance.
- * @return false on success, true on failure.
+ * @return 0 on success, -1 on failure.
  */
 int cell_data_logger_init(BMSLogger *logger);
 
@@ -54,7 +54,7 @@ int cell_data_logger_init(BMSLogger *logger);
  * @brief Logs a new measurement and inserts it in the ring buffer.
  * @param logger Pointer to the logger instance.
  * @param bms_data Pointer to the BMS data containing chip cell voltages and temperatures.
- * @return false on success, true on failure.
+ * @return 0 on success, -1 on failure.
  */
 int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data);
 
@@ -70,7 +70,7 @@ CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger);
  * @param logger Pointer to the logger instance.
  * @param n Number of previous logs to retrieve.
  * @param out_buffer Pointer to the buffer where the readings will be stored.
- * @return false on success, true on failure.
+ * @return 0 on success, -1 on failure.
  */
 int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 			     CellDataEntry_t *out_buffer);
@@ -79,6 +79,7 @@ int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
  * @brief Serial prints the last n cell data logs.
  * @param logger Pointer to the logger instance.
  * @param n Number of previous logs to print.
+ * @return 0 on success, -1 on failure.
  */
 int print_last_n_cell_data_logs(const BMSLogger *logger, size_t n);
 

--- a/Core/Inc/datastructs.h
+++ b/Core/Inc/datastructs.h
@@ -142,6 +142,10 @@ typedef struct {
 
 	bool is_charger_connected;
 
+	/* Cell Data Logging Timestamps */
+	uint32_t voltage_timestamp;
+	uint32_t temperature_timestamp;
+
 	osMutexId_t mutex;
 } acc_data_t;
 

--- a/Core/Inc/datastructs.h
+++ b/Core/Inc/datastructs.h
@@ -142,10 +142,6 @@ typedef struct {
 
 	bool is_charger_connected;
 
-	/* Cell Data Logging Timestamps */
-	uint32_t voltage_timestamp;
-	uint32_t temperature_timestamp;
-
 	osMutexId_t mutex;
 } acc_data_t;
 

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -11,11 +11,12 @@ struct BMSLogger {
 	bool is_initialized;
 	ringbuf_t ring_buff;
 	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
+	osMutexId_t mutex;
 };
 
 static BMSLogger bms_logger = { .is_initialized = false };
 
-BMSLogger *getLogger(void)
+BMSLogger *get_logger(void)
 {
 	return &bms_logger;
 }
@@ -25,12 +26,20 @@ uint32_t get_us_timestamp(void)
 	return __HAL_TIM_GET_COUNTER(&htim2);
 }
 
-bool cell_data_logger_init(BMSLogger *logger)
+static bool get_logger_status(const BMSLogger *logger)
 {
 	if (logger == NULL) {
 		printf("ERROR: Logger is NULL, cannot initialize!\r\n");
+		return false;
+	} else {
 		return true;
 	}
+}
+
+bool cell_data_logger_init(BMSLogger *logger)
+{
+	if (!get_logger_status(logger))
+		return true;
 
 	if (logger->is_initialized) {
 		printf("WARNING: Logger is already initialized!\r\n");
@@ -42,6 +51,12 @@ bool cell_data_logger_init(BMSLogger *logger)
 	rb_init(&logger->ring_buff, logger->cell_data_storage, NUM_OF_READINGS,
 		sizeof(CellDataEntry_t));
 
+	logger->mutex = osMutexNew(NULL);
+	if (logger->mutex == NULL) {
+		printf("ERROR: Data Logger Mutex initialization failed!\r\n");
+		return true;
+	}
+
 	logger->is_initialized = true;
 
 	return false;
@@ -49,13 +64,16 @@ bool cell_data_logger_init(BMSLogger *logger)
 
 bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 {
-	if (logger == NULL) {
-		printf("ERROR: Logger is NULL, cannot log data!\r\n");
+	if (!get_logger_status(logger))
 		return true;
-	}
 
 	if (bms_data == NULL) {
 		printf("ERROR: BMS data is NULL, cannot log data!\r\n");
+		return true;
+	}
+
+	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TICKS) != osOK) {
+		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		return true;
 	}
 
@@ -81,30 +99,38 @@ bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 
 	rb_insert(&logger->ring_buff, &new_entry);
 
+	osMutexRelease(logger->mutex);
+
 	return false;
 }
 
 CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 {
-	if (logger == NULL) {
+	if (!get_logger_status(logger))
 		return NULL;
-	}
 
 	if (logger->ring_buff.curr_elements == 0) {
 		printf("ERROR: No logs available!\r\n");
 		return NULL;
 	}
 
-	return rb_get_head(&logger->ring_buff);
+	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TICKS) != osOK) {
+		printf("ERROR: Failed to aquire data logging mutex!\r\n");
+		return NULL;
+	}
+
+	CellDataEntry_t *last_entry = rb_get_head(&logger->ring_buff);
+
+	osMutexRelease(logger->mutex);
+
+	return last_entry;
 }
 
 bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 			      CellDataEntry_t *out_buffer)
 {
-	if (logger == NULL) {
-		printf("ERROR: Logger is NULL, cannot retrieve logs!\r\n");
+	if (!get_logger_status(logger))
 		return true;
-	}
 
 	if (n > NUM_OF_READINGS) {
 		printf("ERROR: Requested logs exceed limit!\r\n");
@@ -116,24 +142,25 @@ bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 		return true;
 	}
 
+	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TICKS) != osOK) {
+		printf("ERROR: Failed to aquire data logging mutex!\r\n");
+		return true;
+	}
+
 	rb_get_last_n(&logger->ring_buff, out_buffer, n);
+
+	osMutexRelease(logger->mutex);
+
 	return false;
 }
 
 void print_latest_cell_data_log(const BMSLogger *logger)
 {
-	if (logger == NULL) {
-		printf("ERROR: Logger is NULL, cannot retrieve logs!\r\n");
+	if (!get_logger_status(logger))
 		return;
-	}
 
 	const CellDataEntry_t *latest_entry =
 		(const CellDataEntry_t *)cell_data_log_get_last(logger);
-
-	if (latest_entry == NULL) {
-		printf("No data available!!\r\n");
-		return;
-	}
 
 	printf("\nLatest Cell Data Log\r\n");
 	printf("Voltage Measurement Timestamp: %lu µs\r\n",
@@ -159,10 +186,8 @@ void print_latest_cell_data_log(const BMSLogger *logger)
 
 void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 {
-	if (logger == NULL) {
-		printf("ERROR: Logger is NULL, cannot retrieve logs!\r\n");
+	if (!get_logger_status(logger))
 		return;
-	}
 
 	if (n > NUM_OF_READINGS) {
 		printf("ERROR: Requested logs exceed limit!\r\n");

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <string.h>
 
+extern TIM_HandleTypeDef htim2;
+
 struct BMSLogger {
 	ringbuf_t ring_buff;
 	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
@@ -15,6 +17,11 @@ static BMSLogger bms_logger;
 BMSLogger *getLogger(void)
 {
 	return &bms_logger;
+}
+
+uint32_t get_us_timestamp(void)
+{
+	return __HAL_TIM_GET_COUNTER(&htim2);
 }
 
 bool cell_data_logger_init(BMSLogger *logger)
@@ -41,6 +48,9 @@ bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 	CellDataEntry_t new_entry;
 
 	memset(&new_entry, 0, sizeof(CellDataEntry_t));
+
+	new_entry.cell_voltage_timestamp = bms_data->voltage_timestamp;
+	new_entry.cell_temperature_timestamp = bms_data->voltage_timestamp;
 
 	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
 		int cell_count = get_num_cells(&bms_data->chip_data[chip_num]);
@@ -87,7 +97,7 @@ bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 void print_latest_cell_data_log(const BMSLogger *logger)
 {
 	if (logger == NULL) {
-		printf("Logger not initialized!!");
+		printf("Logger not initialized!!\n");
 		return;
 	}
 
@@ -95,22 +105,28 @@ void print_latest_cell_data_log(const BMSLogger *logger)
 		(const CellDataEntry_t *)cell_data_log_get_last(logger);
 
 	if (latest_entry == NULL) {
-		printf("No data available!!\r\n");
+		printf("No data available!!\n");
 		return;
 	}
+
+	printf("\nLatest Cell Data Log\n");
+	printf("Voltage Measurement Timestamp: %lu µs\n",
+	       latest_entry->cell_voltage_timestamp);
+	printf("Temperature Measurement Timestamp: %lu µs\n",
+	       latest_entry->cell_temperature_timestamp);
 
 	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
 		int cell_count = (chip_num % 2 == 0) ? NUM_CELLS_ALPHA :
 						       NUM_CELLS_BETA;
-		printf("Chip %d (%s):\r\n", chip_num,
+
+		printf("\nChip %d (%s):\n", chip_num,
 		       (chip_num % 2 == 0) ? "Alpha" : "Beta");
 
 		for (int cell = 0; cell < cell_count; cell++) {
-			printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C, Timestamp: %lu µs\r\n",
+			printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C\n",
 			       cell + 1,
 			       latest_entry->cell_voltages[chip_num][cell],
-			       latest_entry->cell_temperatures[chip_num][cell],
-			       latest_entry->timestamp[chip_num][cell]);
+			       latest_entry->cell_temperatures[chip_num][cell]);
 		}
 	}
 }
@@ -118,7 +134,7 @@ void print_latest_cell_data_log(const BMSLogger *logger)
 void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 {
 	if (logger == NULL) {
-		printf("Logger not initialized!!");
+		printf("Logger not initialized!!\n");
 		return;
 	}
 
@@ -128,31 +144,33 @@ void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 
 	CellDataEntry_t log_entries[n];
 	if (cell_data_log_get_last_n(logger, n, log_entries)) {
-		printf("Error retrieving log entries!\r\n");
+		printf("Error retrieving log entries!\n");
 		return;
 	}
 
-	printf("Printing Last %zu Cell Data Logs:\r\n", n);
+	printf("\nPrinting Last %zu Cell Data Logs:\n", n);
 
 	for (size_t entry_idx = 0; entry_idx < n; entry_idx++) {
-		printf("\r\n--- Log Entry %zu ---\r\n", entry_idx + 1);
+		printf("\n--- Log Entry %zu ---\n", entry_idx + 1);
+		printf("Voltage Measurement Timestamp: %lu µs\n",
+		       log_entries[entry_idx].cell_voltage_timestamp);
+		printf("Temperature Measurement Timestamp: %lu µs\n",
+		       log_entries[entry_idx].cell_temperature_timestamp);
 
 		for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
 			int cell_count = (chip_num % 2 == 0) ? NUM_CELLS_ALPHA :
 							       NUM_CELLS_BETA;
-			printf("Chip %d (%s):\r\n", chip_num,
+			printf("\nChip %d (%s):\n", chip_num,
 			       (chip_num % 2 == 0) ? "Alpha" : "Beta");
 
 			for (int cell = 0; cell < cell_count; cell++) {
-				printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C, Timestamp: %lu µs\r\n",
+				printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C\n",
 				       cell + 1,
 				       log_entries[entry_idx]
 					       .cell_voltages[chip_num][cell],
 				       log_entries[entry_idx]
 					       .cell_temperatures[chip_num]
-								 [cell],
-				       log_entries[entry_idx]
-					       .timestamp[chip_num][cell]);
+								 [cell]);
 			}
 		}
 	}

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -67,3 +67,63 @@ void cell_data_log_get_last_n(size_t n, CellDataEntry_t *out_buffer)
 
 	rb_get_last_n(&cell_log_ring_buff, out_buffer, n);
 }
+
+void print_latest_cell_data_log(void)
+{
+	CellDataEntry_t *latest_entry = cell_data_log_get_last();
+
+	if (latest_entry == NULL) {
+		printf("No data available!!\r\n");
+		return;
+	}
+
+	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
+		int cell_count = (chip_num % 2 == 0) ? NUM_CELLS_ALPHA :
+						       NUM_CELLS_BETA;
+		printf("Chip %d (%s):\n", chip_num,
+		       (chip_num % 2 == 0) ? "Alpha" : "Beta");
+
+		for (int cell = 0; cell < cell_count; cell++) {
+			printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C, Timestamp: %lu µs\r\n",
+			       cell + 1,
+			       latest_entry->cell_voltages[chip_num][cell],
+			       latest_entry->cell_temperatures[chip_num][cell],
+			       latest_entry->timestamp[chip_num][cell]);
+		}
+	}
+}
+
+void print_last_n_cell_data_logs(size_t n)
+{
+	if (n > NUM_OF_READINGS) {
+		n = NUM_OF_READINGS;
+	}
+
+	CellDataEntry_t log_entries[n];
+	rb_get_last_n(&cell_log_ring_buff, log_entries, n);
+
+	printf("Printing Last %zu Cell Data Logs:\r\n", n);
+
+	for (size_t entry_idx = 0; entry_idx < n; entry_idx++) {
+		printf("\r\n--- Log Entry %zu ---\r\n", entry_idx + 1);
+
+		for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
+			int cell_count = (chip_num % 2 == 0) ? NUM_CELLS_ALPHA :
+							       NUM_CELLS_BETA;
+			printf("Chip %d (%s):\r\n", chip_num,
+			       (chip_num % 2 == 0) ? "Alpha" : "Beta");
+
+			for (int cell = 0; cell < cell_count; cell++) {
+				printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C, Timestamp: %lu µs\r\n",
+				       cell + 1,
+				       log_entries[entry_idx]
+					       .cell_voltages[chip_num][cell],
+				       log_entries[entry_idx]
+					       .cell_temperatures[chip_num]
+								 [cell],
+				       log_entries[entry_idx]
+					       .timestamp[chip_num][cell]);
+			}
+		}
+	}
+}

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -29,9 +29,10 @@ int cell_data_logger_init(BMSLogger *logger)
 		sizeof(CellDataEntry_t));
 
 	logger->mutex = osMutexNew(NULL);
+
 	if (logger->mutex == NULL) {
 		printf("ERROR: Data Logger Mutex initialization failed!\r\n");
-		return true;
+		return -1;
 	}
 
 	return 0;
@@ -39,12 +40,14 @@ int cell_data_logger_init(BMSLogger *logger)
 
 int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 {
+	int status = -1;
+
 	assert(logger != NULL);
 	assert(bms_data != NULL);
 
 	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
-		return -1;
+		goto exit;
 	}
 
 	CellDataEntry_t new_entry;
@@ -69,106 +72,76 @@ int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 
 	rb_insert(&logger->ring_buff, &new_entry);
 
+	status = 0;
+
 	osMutexRelease(logger->mutex);
 
-	return 0;
+exit:
+	return status;
 }
 
 CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 {
+	CellDataEntry_t *last_entry = NULL;
+
 	assert(logger != NULL);
 
 	if (logger->ring_buff.curr_elements == 0) {
 		printf("ERROR: No logs available!\r\n");
-		return NULL;
+		goto exit;
 	}
 
 	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
-		return NULL;
+		goto exit;
 	}
 
-	CellDataEntry_t *last_entry = rb_get_head(&logger->ring_buff);
+	last_entry = rb_get_head(&logger->ring_buff);
 
 	osMutexRelease(logger->mutex);
 
+exit:
 	return last_entry;
 }
 
 int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 			     CellDataEntry_t *out_buffer)
 {
-	assert(logger != NULL);
+	int status = -1;
 
-	if (n > NUM_OF_READINGS) {
-		printf("ERROR: Requested logs exceed limit!\r\n");
-		return -1;
-	}
+	assert(logger != NULL);
 
 	if (n > logger->ring_buff.curr_elements) {
 		printf("ERROR: Not enough logs available!\r\n");
-		return -1;
+		goto exit;
 	}
 
 	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
-		return -1;
+		goto exit;
 	}
 
 	rb_get_last_n(&logger->ring_buff, out_buffer, n);
 
+	status = 0;
+
 	osMutexRelease(logger->mutex);
 
-	return 0;
+exit:
+	return status;
 }
 
-void print_latest_cell_data_log(const BMSLogger *logger)
+int print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 {
+	int status = -1;
+
 	assert(logger != NULL);
-
-	const CellDataEntry_t *latest_entry =
-		(const CellDataEntry_t *)cell_data_log_get_last(logger);
-
-	printf("\nLatest Cell Data Log\r\n");
-	printf("Voltage Measurement Timestamp: %lu µs\r\n",
-	       latest_entry->cell_voltage_timestamp);
-	printf("Temperature Measurement Timestamp: %lu µs\r\n",
-	       latest_entry->cell_temperature_timestamp);
-
-	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
-		int cell_count = (chip_num % 2 == 0) ? NUM_CELLS_ALPHA :
-						       NUM_CELLS_BETA;
-
-		printf("\nChip %d (%s):\r\n", chip_num,
-		       (chip_num % 2 == 0) ? "Alpha" : "Beta");
-
-		for (int cell = 0; cell < cell_count; cell++) {
-			printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C\r\n",
-			       cell + 1,
-			       latest_entry->cell_voltages[chip_num][cell],
-			       latest_entry->cell_temperatures[chip_num][cell]);
-		}
-	}
-}
-
-void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
-{
-	assert(logger != NULL);
-
-	if (n > NUM_OF_READINGS) {
-		printf("ERROR: Requested logs exceed limit!\r\n");
-		return;
-	}
-
-	if (n > logger->ring_buff.curr_elements) {
-		printf("ERROR: Not enough logs available!\r\n");
-		return;
-	}
 
 	CellDataEntry_t log_entries[n];
+
 	if (cell_data_log_get_last_n(logger, n, log_entries)) {
 		printf("Error retrieving log entries!\r\n");
-		return;
+		goto exit;
 	}
 
 	printf("\r\nPrinting Last %u Cell Data Logs:\r\n", n);
@@ -197,4 +170,9 @@ void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 			}
 		}
 	}
+
+	status = 0;
+
+exit:
+	return status;
 }

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -14,6 +14,30 @@ struct BMSLogger {
 	osMutexId_t mutex;
 };
 
+static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
+{
+	assert(entry != NULL);
+
+	printf("\r\n--- Log Entry %zu ---\r\n", entry_idx + 1);
+	printf("Voltage Measurement Timestamp: %lu µs\r\n",
+	       entry->cell_voltage_timestamp);
+	printf("Temperature Measurement Timestamp: %lu µs\r\n",
+	       entry->cell_temperature_timestamp);
+
+	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
+		int cell_count = (chip_num % 2 == 0) ? NUM_CELLS_ALPHA :
+						       NUM_CELLS_BETA;
+		printf("\r\nChip %d (%s):\r\n", chip_num,
+		       (chip_num % 2 == 0) ? "Alpha" : "Beta");
+
+		for (int cell = 0; cell < cell_count; cell++) {
+			printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C\r\n",
+			       cell + 1, entry->cell_voltages[chip_num][cell],
+			       entry->cell_temperatures[chip_num][cell]);
+		}
+	}
+}
+
 uint32_t get_us_timestamp(void)
 {
 	return __HAL_TIM_GET_COUNTER(&htim2);
@@ -41,7 +65,6 @@ int cell_data_logger_init(BMSLogger *logger)
 int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 {
 	int status = -1;
-
 	assert(logger != NULL);
 	assert(bms_data != NULL);
 
@@ -83,7 +106,6 @@ exit:
 CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 {
 	CellDataEntry_t *last_entry = NULL;
-
 	assert(logger != NULL);
 
 	if (logger->ring_buff.curr_elements == 0) {
@@ -108,7 +130,6 @@ int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 			     CellDataEntry_t *out_buffer)
 {
 	int status = -1;
-
 	assert(logger != NULL);
 
 	if (n > logger->ring_buff.curr_elements) {
@@ -134,7 +155,6 @@ exit:
 int print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 {
 	int status = -1;
-
 	assert(logger != NULL);
 
 	CellDataEntry_t log_entries[n];
@@ -144,31 +164,9 @@ int print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 		goto exit;
 	}
 
-	printf("\r\nPrinting Last %u Cell Data Logs:\r\n", n);
-
+	printf("\r\nPrinting Last %zu Cell Data Logs:\r\n", n);
 	for (size_t entry_idx = 0; entry_idx < n; entry_idx++) {
-		printf("\r\n--- Log Entry %u ---\r\n", entry_idx + 1);
-		printf("Voltage Measurement Timestamp: %lu µs\r\n",
-		       log_entries[entry_idx].cell_voltage_timestamp);
-		printf("Temperature Measurement Timestamp: %lu µs\r\n",
-		       log_entries[entry_idx].cell_temperature_timestamp);
-
-		for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
-			int cell_count = (chip_num % 2 == 0) ? NUM_CELLS_ALPHA :
-							       NUM_CELLS_BETA;
-			printf("\r\nChip %d (%s):\r\n", chip_num,
-			       (chip_num % 2 == 0) ? "Alpha" : "Beta");
-
-			for (int cell = 0; cell < cell_count; cell++) {
-				printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C\r\n",
-				       cell + 1,
-				       log_entries[entry_idx]
-					       .cell_voltages[chip_num][cell],
-				       log_entries[entry_idx]
-					       .cell_temperatures[chip_num]
-								 [cell]);
-			}
-		}
+		print_cell_data(&log_entries[entry_idx], entry_idx);
 	}
 
 	status = 0;

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -53,3 +53,17 @@ void cell_data_log_measurement(acc_data_t *bms_data)
 
 	rb_insert(&cell_log_ring_buff, &new_entry);
 }
+
+CellDataEntry_t *cell_data_log_get_last(void)
+{
+	return (CellDataEntry_t *)rb_get_head(&cell_log_ring_buff);
+}
+
+void cell_data_log_get_last_n(size_t n, CellDataEntry_t *out_buffer)
+{
+	if (n > NUM_OF_READINGS) {
+		n = NUM_OF_READINGS;
+	}
+
+	rb_get_last_n(&cell_log_ring_buff, out_buffer, n);
+}

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -8,7 +8,6 @@
 extern TIM_HandleTypeDef htim2;
 
 struct BMSLogger {
-	bool is_initialized;
 	ringbuf_t ring_buff;
 	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
 	osMutexId_t mutex;
@@ -19,25 +18,20 @@ uint32_t get_us_timestamp(void)
 	return __HAL_TIM_GET_COUNTER(&htim2);
 }
 
-static bool get_logger_status(const BMSLogger *logger)
+static int get_logger_status(const BMSLogger *logger)
 {
 	if (logger == NULL) {
 		printf("ERROR: Logger is NULL, cannot initialize!\r\n");
-		return false;
+		return -1;
 	} else {
-		return true;
+		return 0;
 	}
 }
 
-bool cell_data_logger_init(BMSLogger *logger)
+int cell_data_logger_init(BMSLogger *logger)
 {
 	if (!get_logger_status(logger))
-		return true;
-
-	if (logger->is_initialized) {
-		printf("WARNING: Logger is already initialized!\r\n");
-		return true;
-	}
+		return -1;
 
 	memset(logger, 0, sizeof(BMSLogger));
 
@@ -50,24 +44,22 @@ bool cell_data_logger_init(BMSLogger *logger)
 		return true;
 	}
 
-	logger->is_initialized = true;
-
-	return false;
+	return 0;
 }
 
-bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
+int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 {
 	if (!get_logger_status(logger))
-		return true;
+		return -1;
 
 	if (bms_data == NULL) {
 		printf("ERROR: BMS data is NULL, cannot log data!\r\n");
-		return true;
+		return -1;
 	}
 
 	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
-		return true;
+		return -1;
 	}
 
 	CellDataEntry_t new_entry;
@@ -94,7 +86,7 @@ bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 
 	osMutexRelease(logger->mutex);
 
-	return false;
+	return 0;
 }
 
 CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
@@ -119,32 +111,32 @@ CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 	return last_entry;
 }
 
-bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
-			      CellDataEntry_t *out_buffer)
+int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
+			     CellDataEntry_t *out_buffer)
 {
 	if (!get_logger_status(logger))
-		return true;
+		return -1;
 
 	if (n > NUM_OF_READINGS) {
 		printf("ERROR: Requested logs exceed limit!\r\n");
-		return true;
+		return -1;
 	}
 
 	if (n > logger->ring_buff.curr_elements) {
 		printf("ERROR: Not enough logs available!\r\n");
-		return true;
+		return -1;
 	}
 
 	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
-		return true;
+		return -1;
 	}
 
 	rb_get_last_n(&logger->ring_buff, out_buffer, n);
 
 	osMutexRelease(logger->mutex);
 
-	return false;
+	return 0;
 }
 
 void print_latest_cell_data_log(const BMSLogger *logger)

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -57,21 +57,21 @@ static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
 }
 
 /**
- * @brief Retrieves the global instance of the BMSLogger.
- * @return Pointer to the global `BMSLogger` instance.
- */
-struct BMSLogger *get_logger(void)
-{
-	return &bms_logger;
-}
-
-/**
  * @brief Retrieves the current timestamp in microseconds from TIM2.
  * @return The current timestamp in microseconds.
  */
 uint32_t get_us_timestamp(void)
 {
 	return __HAL_TIM_GET_COUNTER(&htim2);
+}
+
+/**
+ * @brief Retrieves the global instance of the BMSLogger.
+ * @return Pointer to the global `BMSLogger` instance.
+ */
+struct BMSLogger *get_logger(void)
+{
+	return &bms_logger;
 }
 
 /**
@@ -118,9 +118,6 @@ int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data)
 	CellDataEntry_t new_entry;
 
 	memset(&new_entry, 0, sizeof(CellDataEntry_t));
-
-	new_entry.cell_voltage_timestamp = bms_data->voltage_timestamp;
-	new_entry.cell_temperature_timestamp = bms_data->temperature_timestamp;
 
 	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
 		int cell_count = get_num_cells(&bms_data->chip_data[chip_num]);

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -1,3 +1,8 @@
+/**
+ * @file cell_data_logging.c
+ * @brief Implementation of cell voltage and temperature data logging.
+ */
+
 #include "cell_data_logging.h"
 #include "analyzer.h"
 #include "bmsConfig.h"
@@ -6,14 +11,24 @@
 #include <string.h>
 #include <assert.h>
 
+// Used to get microsecond timestamps.
 extern TIM_HandleTypeDef htim2;
 
+/**
+ * @struct BMSLogger
+ * @brief Internal structure to manage logging system.
+ */
 struct BMSLogger {
 	ringbuf_t ring_buff;
 	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
 	osMutexId_t mutex;
 };
 
+/**
+ * @brief Prints a single cell data entry.
+ * @param entry Pointer to the cell data entry to print.
+ * @param entry_idx Index of the entry.
+ */
 static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
 {
 	assert(entry != NULL);
@@ -38,11 +53,20 @@ static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
 	}
 }
 
+/**
+ * @brief Retrieves the current timestamp in microseconds from TIM2.
+ * @return The current timestamp in microseconds.
+ */
 uint32_t get_us_timestamp(void)
 {
 	return __HAL_TIM_GET_COUNTER(&htim2);
 }
 
+/**
+ * @brief Initializes a BMSLogger instance.
+ * @param logger Pointer to the logger instance.
+ * @return 0 on success, -1 on failure.
+ */
 int cell_data_logger_init(BMSLogger *logger)
 {
 	assert(logger != NULL);
@@ -62,6 +86,12 @@ int cell_data_logger_init(BMSLogger *logger)
 	return 0;
 }
 
+/**
+ * @brief Logs a new measurement and inserts it in the ring buffer.
+ * @param logger Pointer to the logger instance.
+ * @param bms_data Pointer to the BMS data containing chip cell voltages and temperatures.
+ * @return 0 on success, -1 on failure.
+ */
 int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 {
 	int status = -1;
@@ -103,6 +133,11 @@ exit:
 	return status;
 }
 
+/**
+ * @brief Gets the most recent cell data log from the buffer.
+ * @param logger Pointer to the logger instance.
+ * @return Pointer to the most recent data entry, or NULL if the logger is empty.
+ */
 CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 {
 	CellDataEntry_t *last_entry = NULL;
@@ -126,6 +161,13 @@ exit:
 	return last_entry;
 }
 
+/**
+ * @brief Retrieves the last n cell data logs from the buffer.
+ * @param logger Pointer to the logger instance.
+ * @param n Number of previous logs to retrieve.
+ * @param out_buffer Pointer to the buffer where the readings will be stored.
+ * @return 0 on success, -1 on failure.
+ */
 int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 			     CellDataEntry_t *out_buffer)
 {
@@ -152,6 +194,12 @@ exit:
 	return status;
 }
 
+/**
+ * @brief Serial prints the last n cell data logs.
+ * @param logger Pointer to the logger instance.
+ * @param n Number of previous logs to print.
+ * @return 0 on success, -1 on failure.
+ */
 int print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 {
 	int status = -1;

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -27,6 +27,7 @@ uint32_t get_us_timestamp(void)
 bool cell_data_logger_init(BMSLogger *logger)
 {
 	if (logger == NULL) {
+		printf("ERROR: Logger is NULL, cannot initialize!\r\n");
 		return true;
 	}
 
@@ -40,8 +41,13 @@ bool cell_data_logger_init(BMSLogger *logger)
 
 bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 {
-	if (logger == NULL || bms_data == NULL) {
-		printf("No BMS data to log!!\r\n");
+	if (logger == NULL) {
+		printf("ERROR: Logger is NULL, cannot log data!\r\n");
+		return true;
+	}
+
+	if (bms_data == NULL) {
+		printf("ERROR: BMS data is NULL, cannot log data!\r\n");
 		return true;
 	}
 
@@ -50,7 +56,7 @@ bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 	memset(&new_entry, 0, sizeof(CellDataEntry_t));
 
 	new_entry.cell_voltage_timestamp = bms_data->voltage_timestamp;
-	new_entry.cell_temperature_timestamp = bms_data->voltage_timestamp;
+	new_entry.cell_temperature_timestamp = bms_data->temperature_timestamp;
 
 	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
 		int cell_count = get_num_cells(&bms_data->chip_data[chip_num]);
@@ -76,6 +82,11 @@ CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 		return NULL;
 	}
 
+	if (logger->ring_buff.curr_elements == 0) {
+		printf("ERROR: No logs available!\r\n");
+		return NULL;
+	}
+
 	return rb_get_head(&logger->ring_buff);
 }
 
@@ -83,11 +94,18 @@ bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 			      CellDataEntry_t *out_buffer)
 {
 	if (logger == NULL) {
+		printf("ERROR: Logger is NULL, cannot retrieve logs!\r\n");
 		return true;
 	}
 
 	if (n > NUM_OF_READINGS) {
-		n = NUM_OF_READINGS;
+		printf("ERROR: Requested logs exceed limit!\r\n");
+		return true;
+	}
+
+	if (n > logger->ring_buff.curr_elements) {
+		printf("ERROR: Not enough logs available!\r\n");
+		return true;
 	}
 
 	rb_get_last_n(&logger->ring_buff, out_buffer, n);
@@ -97,7 +115,7 @@ bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 void print_latest_cell_data_log(const BMSLogger *logger)
 {
 	if (logger == NULL) {
-		printf("Logger not initialized!!\n");
+		printf("ERROR: Logger is NULL, cannot retrieve logs!\r\n");
 		return;
 	}
 
@@ -105,25 +123,25 @@ void print_latest_cell_data_log(const BMSLogger *logger)
 		(const CellDataEntry_t *)cell_data_log_get_last(logger);
 
 	if (latest_entry == NULL) {
-		printf("No data available!!\n");
+		printf("No data available!!\r\n");
 		return;
 	}
 
-	printf("\nLatest Cell Data Log\n");
-	printf("Voltage Measurement Timestamp: %lu µs\n",
+	printf("\nLatest Cell Data Log\r\n");
+	printf("Voltage Measurement Timestamp: %lu µs\r\n",
 	       latest_entry->cell_voltage_timestamp);
-	printf("Temperature Measurement Timestamp: %lu µs\n",
+	printf("Temperature Measurement Timestamp: %lu µs\r\n",
 	       latest_entry->cell_temperature_timestamp);
 
 	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
 		int cell_count = (chip_num % 2 == 0) ? NUM_CELLS_ALPHA :
 						       NUM_CELLS_BETA;
 
-		printf("\nChip %d (%s):\n", chip_num,
+		printf("\nChip %d (%s):\r\n", chip_num,
 		       (chip_num % 2 == 0) ? "Alpha" : "Beta");
 
 		for (int cell = 0; cell < cell_count; cell++) {
-			printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C\n",
+			printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C\r\n",
 			       cell + 1,
 			       latest_entry->cell_voltages[chip_num][cell],
 			       latest_entry->cell_temperatures[chip_num][cell]);
@@ -134,37 +152,43 @@ void print_latest_cell_data_log(const BMSLogger *logger)
 void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 {
 	if (logger == NULL) {
-		printf("Logger not initialized!!\n");
+		printf("ERROR: Logger is NULL, cannot retrieve logs!\r\n");
 		return;
 	}
 
 	if (n > NUM_OF_READINGS) {
-		n = NUM_OF_READINGS;
+		printf("ERROR: Requested logs exceed limit!\r\n");
+		return;
+	}
+
+	if (n > logger->ring_buff.curr_elements) {
+		printf("ERROR: Not enough logs available!\r\n");
+		return;
 	}
 
 	CellDataEntry_t log_entries[n];
 	if (cell_data_log_get_last_n(logger, n, log_entries)) {
-		printf("Error retrieving log entries!\n");
+		printf("Error retrieving log entries!\r\n");
 		return;
 	}
 
-	printf("\nPrinting Last %zu Cell Data Logs:\n", n);
+	printf("\r\nPrinting Last %zu Cell Data Logs:\r\n", n);
 
 	for (size_t entry_idx = 0; entry_idx < n; entry_idx++) {
-		printf("\n--- Log Entry %zu ---\n", entry_idx + 1);
-		printf("Voltage Measurement Timestamp: %lu µs\n",
+		printf("\r\n--- Log Entry %zu ---\r\n", entry_idx + 1);
+		printf("Voltage Measurement Timestamp: %lu µs\r\n",
 		       log_entries[entry_idx].cell_voltage_timestamp);
-		printf("Temperature Measurement Timestamp: %lu µs\n",
+		printf("Temperature Measurement Timestamp: %lu µs\r\n",
 		       log_entries[entry_idx].cell_temperature_timestamp);
 
 		for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
 			int cell_count = (chip_num % 2 == 0) ? NUM_CELLS_ALPHA :
 							       NUM_CELLS_BETA;
-			printf("\nChip %d (%s):\n", chip_num,
+			printf("\r\nChip %d (%s):\r\n", chip_num,
 			       (chip_num % 2 == 0) ? "Alpha" : "Beta");
 
 			for (int cell = 0; cell < cell_count; cell++) {
-				printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C\n",
+				printf("  Cell %d: Voltage: %.3f V, Temperature: %.2f C\r\n",
 				       cell + 1,
 				       log_entries[entry_idx]
 					       .cell_voltages[chip_num][cell],

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -15,6 +15,31 @@
 extern TIM_HandleTypeDef htim2;
 
 /**
+ * @brief Retrieves the current timestamp in microseconds from TIM2.
+ * @return The current timestamp in microseconds.
+ */
+static inline uint32_t get_us_timestamp(void)
+{
+	return __HAL_TIM_GET_COUNTER(&htim2);
+}
+
+/**
+ * @brief Retrieves the next writable log entry from the buffer.
+ * @param logger Pointer to the BMSLogger instance.
+ * @return Pointer to the writable log entry.
+ */
+static CellDataEntry_t *get_writable_log_entry(struct BMSLogger *logger)
+{
+	assert(logger != NULL);
+
+	size_t next_idx = logger->ring_buff.head_idx;
+
+	CellDataEntry_t *entry = &logger->cell_data_storage[next_idx];
+
+	return entry;
+}
+
+/**
  * @brief Prints a single cell data entry.
  * @param entry Pointer to the cell data entry to print.
  * @param entry_idx Index of the entry.
@@ -23,7 +48,7 @@ static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
 {
 	assert(entry != NULL);
 
-	printf("\r\n--- Log Entry %zu ---\r\n", entry_idx + 1);
+	printf("\r\n--- Log Entry %u ---\r\n", entry_idx + 1);
 	printf("Voltage Measurement Timestamp: %lu µs\r\n",
 	       entry->cell_voltage_timestamp);
 	printf("Temperature Measurement Timestamp: %lu µs\r\n",
@@ -41,15 +66,6 @@ static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
 			       entry->cell_temperatures[chip_num][cell]);
 		}
 	}
-}
-
-/**
- * @brief Retrieves the current timestamp in microseconds from TIM2.
- * @return The current timestamp in microseconds.
- */
-static uint32_t get_us_timestamp(void)
-{
-	return __HAL_TIM_GET_COUNTER(&htim2);
 }
 
 /**
@@ -77,7 +93,7 @@ int cell_data_logger_init(struct BMSLogger *logger)
 }
 
 /**
- * @brief Assigns a voltage timestamp to the current log entry. 
+ * @brief Assigns a voltage timestamp to the current log entry.
  * @param logger Pointer to the BMSLogger instance.
  * @return 0 on success, -1 on failure.
  */
@@ -86,23 +102,19 @@ int cell_data_logger_timestamp_voltage(struct BMSLogger *logger)
 	assert(logger != NULL);
 
 	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
-		printf("ERROR: Failed to aquire data logging mutex!\r\n");
+		printf("ERROR: Failed to acquire data logging mutex!\r\n");
 		return -1;
 	}
 
-	if (!logger->first_timestamp_set) {
-		size_t next_idx = (logger->ring_buff.head_idx + 1) %
-				  logger->ring_buff.size;
+	CellDataEntry_t *entry = get_writable_log_entry(logger);
 
-		logger->latest_entry = &logger->cell_data_storage[next_idx];
+	if (!entry)
+		return -1;
 
-		logger->first_timestamp_set = true;
-	}
-
-	assert(logger->latest_entry != NULL);
-	logger->latest_entry->cell_voltage_timestamp = get_us_timestamp();
+	entry->cell_voltage_timestamp = get_us_timestamp();
 
 	osMutexRelease(logger->mutex);
+
 	return 0;
 }
 
@@ -116,31 +128,27 @@ int cell_data_logger_timestamp_therms(struct BMSLogger *logger)
 	assert(logger != NULL);
 
 	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
-		printf("ERROR: Failed to aquire data logging mutex!\r\n");
+		printf("ERROR: Failed to acquire data logging mutex!\r\n");
 		return -1;
 	}
 
-	if (!logger->first_timestamp_set) {
-		size_t next_idx = (logger->ring_buff.head_idx + 1) %
-				  logger->ring_buff.size;
+	CellDataEntry_t *entry = get_writable_log_entry(logger);
 
-		logger->latest_entry = &logger->cell_data_storage[next_idx];
+	if (!entry)
+		return -1;
 
-		logger->first_timestamp_set = true;
-	}
-
-	assert(logger->latest_entry != NULL);
-	logger->latest_entry->cell_temperature_timestamp = get_us_timestamp();
+	entry->cell_temperature_timestamp = get_us_timestamp();
 
 	osMutexRelease(logger->mutex);
+
 	return 0;
 }
 
 /**
  * @brief Logs a new measurement and inserts it into the ring buffer.
  * 
- * @note The user is responsible for ensuring the timestamps are set before calling this function.
- * 
+ * @note The user must ensure timestamps are set before calling this function.
+ *
  * @param logger Pointer to the BMSLogger instance managing the ring buffer.
  * @param bms_data Pointer to the BMS data structure containing cell voltages and temperatures.
  * @return 0 on success, -1 on failure.
@@ -152,13 +160,13 @@ int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data)
 	assert(bms_data != NULL);
 
 	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
-		printf("ERROR: Failed to aquire data logging mutex!\r\n");
+		printf("ERROR: Failed to acquire data logging mutex!\r\n");
 		goto exit;
 	}
 
-	if (logger->latest_entry == NULL) {
-		printf("ERROR: No timestamped entry available!\r\n");
-		osMutexRelease(logger->mutex);
+	CellDataEntry_t *entry = get_writable_log_entry(logger);
+	if (!entry) {
+		printf("ERROR: No writable log entry available!\r\n");
 		goto exit;
 	}
 
@@ -166,53 +174,24 @@ int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data)
 		int cell_count = get_num_cells(&bms_data->chip_data[chip_num]);
 
 		for (int cell = 0; cell < cell_count; cell++) {
-			logger->latest_entry->cell_voltages[chip_num][cell] =
+			entry->cell_voltages[chip_num][cell] =
 				bms_data->chip_data[chip_num]
 					.cell_voltages[cell];
-
-			logger->latest_entry->cell_temperatures[chip_num][cell] =
+			entry->cell_temperatures[chip_num][cell] =
 				bms_data->chip_data[chip_num].cell_temp[cell];
 		}
 	}
 
-	rb_insert(&logger->ring_buff, logger->latest_entry);
-	logger->latest_entry = NULL;
-	logger->first_timestamp_set = false;
+	rb_insert(&logger->ring_buff, entry);
 
 	status = 0;
+
 	osMutexRelease(logger->mutex);
+
 	return status;
 
 exit:
 	return status;
-}
-
-/**
- * @brief Gets the most recent cell data log from the buffer.
- * @param logger Pointer to the logger instance.
- * @return Pointer to the most recent data entry, or NULL if the logger is empty.
- */
-CellDataEntry_t *cell_data_log_get_last(const struct BMSLogger *logger)
-{
-	CellDataEntry_t *last_entry = NULL;
-	assert(logger != NULL);
-
-	if (logger->ring_buff.curr_elements == 0) {
-		printf("ERROR: No logs available!\r\n");
-		goto exit;
-	}
-
-	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
-		printf("ERROR: Failed to aquire data logging mutex!\r\n");
-		goto exit;
-	}
-
-	last_entry = rb_get_head(&logger->ring_buff);
-
-	osMutexRelease(logger->mutex);
-
-exit:
-	return last_entry;
 }
 
 /**
@@ -234,7 +213,7 @@ int cell_data_log_get_last_n(const struct BMSLogger *logger, size_t n,
 	}
 
 	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
-		printf("ERROR: Failed to aquire data logging mutex!\r\n");
+		printf("ERROR: Failed to acquire data logging mutex!\r\n");
 		goto exit;
 	}
 
@@ -266,7 +245,7 @@ int print_last_n_cell_data_logs(const struct BMSLogger *logger, size_t n)
 		goto exit;
 	}
 
-	printf("\r\nPrinting Last %zu Cell Data Logs:\r\n", n);
+	printf("\r\nPrinting Last %u Cell Data Logs:\r\n", n);
 	for (size_t entry_idx = 0; entry_idx < n; entry_idx++) {
 		print_cell_data(&log_entries[entry_idx], entry_idx);
 	}

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -5,6 +5,18 @@
 #include <stdio.h>
 #include <string.h>
 
+struct BMSLogger {
+	ringbuf_t ring_buff;
+	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
+};
+
+static BMSLogger bms_logger;
+
+BMSLogger *getLogger(void)
+{
+	return &bms_logger;
+}
+
 bool cell_data_logger_init(BMSLogger *logger)
 {
 	if (logger == NULL) {

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -45,7 +45,7 @@ int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 	assert(logger != NULL);
 	assert(bms_data != NULL);
 
-	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
+	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		goto exit;
 	}
@@ -91,7 +91,7 @@ CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 		goto exit;
 	}
 
-	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
+	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		goto exit;
 	}
@@ -116,7 +116,7 @@ int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 		goto exit;
 	}
 
-	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
+	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		goto exit;
 	}

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -23,3 +23,33 @@ void cell_data_logger_init(void)
 	rb_init(&cell_log_ring_buff, cell_data_storage, NUM_OF_READINGS,
 		sizeof(CellDataEntry_t));
 }
+
+void cell_data_log_measurement(acc_data_t *bms_data)
+{
+	if (bms_data == NULL) {
+		printf("No BMS data to log!!\r\n");
+		return;
+	}
+
+	CellDataEntry_t new_entry;
+
+	memset(&new_entry, 0, sizeof(CellDataEntry_t));
+
+	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
+		int cell_count = get_num_cells(&bms_data->chip_data[chip_num]);
+
+		for (int cell = 0; cell < cell_count; cell++) {
+			new_entry.cell_voltages[chip_num][cell] =
+				bms_data->chip_data[chip_num]
+					.cell_voltages[cell];
+
+			new_entry.cell_temperatures[chip_num][cell] =
+				bms_data->chip_data[chip_num].cell_temp[cell];
+
+			new_entry.timestamp[chip_num][cell] =
+				get_us_timestamp();
+		}
+	}
+
+	rb_insert(&cell_log_ring_buff, &new_entry);
+}

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -24,6 +24,9 @@ struct BMSLogger {
 	osMutexId_t mutex;
 };
 
+/* Global instance of BMSLogger */
+static struct BMSLogger bms_logger;
+
 /**
  * @brief Prints a single cell data entry.
  * @param entry Pointer to the cell data entry to print.
@@ -54,6 +57,15 @@ static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
 }
 
 /**
+ * @brief Retrieves the global instance of the BMSLogger.
+ * @return Pointer to the global `BMSLogger` instance.
+ */
+struct BMSLogger *get_logger(void)
+{
+	return &bms_logger;
+}
+
+/**
  * @brief Retrieves the current timestamp in microseconds from TIM2.
  * @return The current timestamp in microseconds.
  */
@@ -67,11 +79,11 @@ uint32_t get_us_timestamp(void)
  * @param logger Pointer to the logger instance.
  * @return 0 on success, -1 on failure.
  */
-int cell_data_logger_init(BMSLogger *logger)
+int cell_data_logger_init(struct BMSLogger *logger)
 {
 	assert(logger != NULL);
 
-	memset(logger, 0, sizeof(BMSLogger));
+	memset(logger, 0, sizeof(struct BMSLogger));
 
 	rb_init(&logger->ring_buff, logger->cell_data_storage, NUM_OF_READINGS,
 		sizeof(CellDataEntry_t));
@@ -92,7 +104,7 @@ int cell_data_logger_init(BMSLogger *logger)
  * @param bms_data Pointer to the BMS data containing chip cell voltages and temperatures.
  * @return 0 on success, -1 on failure.
  */
-int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
+int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data)
 {
 	int status = -1;
 	assert(logger != NULL);
@@ -138,7 +150,7 @@ exit:
  * @param logger Pointer to the logger instance.
  * @return Pointer to the most recent data entry, or NULL if the logger is empty.
  */
-CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
+CellDataEntry_t *cell_data_log_get_last(const struct BMSLogger *logger)
 {
 	CellDataEntry_t *last_entry = NULL;
 	assert(logger != NULL);
@@ -168,7 +180,7 @@ exit:
  * @param out_buffer Pointer to the buffer where the readings will be stored.
  * @return 0 on success, -1 on failure.
  */
-int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
+int cell_data_log_get_last_n(const struct BMSLogger *logger, size_t n,
 			     CellDataEntry_t *out_buffer)
 {
 	int status = -1;
@@ -200,7 +212,7 @@ exit:
  * @param n Number of previous logs to print.
  * @return 0 on success, -1 on failure.
  */
-int print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
+int print_last_n_cell_data_logs(const struct BMSLogger *logger, size_t n)
 {
 	int status = -1;
 	assert(logger != NULL);

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -72,7 +72,7 @@ bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 		return true;
 	}
 
-	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TICKS) != osOK) {
+	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		return true;
 	}
@@ -114,7 +114,7 @@ CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 		return NULL;
 	}
 
-	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TICKS) != osOK) {
+	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		return NULL;
 	}
@@ -142,7 +142,7 @@ bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 		return true;
 	}
 
-	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TICKS) != osOK) {
+	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		return true;
 	}
@@ -205,10 +205,10 @@ void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 		return;
 	}
 
-	printf("\r\nPrinting Last %zu Cell Data Logs:\r\n", n);
+	printf("\r\nPrinting Last %u Cell Data Logs:\r\n", n);
 
 	for (size_t entry_idx = 0; entry_idx < n; entry_idx++) {
-		printf("\r\n--- Log Entry %zu ---\r\n", entry_idx + 1);
+		printf("\r\n--- Log Entry %u ---\r\n", entry_idx + 1);
 		printf("Voltage Measurement Timestamp: %lu µs\r\n",
 		       log_entries[entry_idx].cell_voltage_timestamp);
 		printf("Temperature Measurement Timestamp: %lu µs\r\n",

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -1,34 +1,29 @@
 #include "cell_data_logging.h"
 #include "analyzer.h"
+#include "bmsConfig.h"
 #include "stm32f4xx_hal.h"
 #include <stdio.h>
 #include <string.h>
 
-// For timestamps
-extern TIM_HandleTypeDef htim2;
-
-// Ring buffer
-static ringbuf_t cell_log_ring_buff;
-
-// Storage buffer for cell data
-static CellDataEntry_t cell_data_storage[NUM_OF_READINGS] = { 0 };
-
-static uint32_t get_us_timestamp(void)
+bool cell_data_logger_init(BMSLogger *logger)
 {
-	return __HAL_TIM_GET_COUNTER(&htim2);
-}
+	if (logger == NULL) {
+		return true;
+	}
 
-void cell_data_logger_init(void)
-{
-	rb_init(&cell_log_ring_buff, cell_data_storage, NUM_OF_READINGS,
+	memset(logger, 0, sizeof(BMSLogger));
+
+	rb_init(&logger->ring_buff, logger->cell_data_storage, NUM_OF_READINGS,
 		sizeof(CellDataEntry_t));
+
+	return false;
 }
 
-void cell_data_log_measurement(acc_data_t *bms_data)
+bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 {
-	if (bms_data == NULL) {
+	if (logger == NULL || bms_data == NULL) {
 		printf("No BMS data to log!!\r\n");
-		return;
+		return true;
 	}
 
 	CellDataEntry_t new_entry;
@@ -45,32 +40,47 @@ void cell_data_log_measurement(acc_data_t *bms_data)
 
 			new_entry.cell_temperatures[chip_num][cell] =
 				bms_data->chip_data[chip_num].cell_temp[cell];
-
-			new_entry.timestamp[chip_num][cell] =
-				get_us_timestamp();
 		}
 	}
 
-	rb_insert(&cell_log_ring_buff, &new_entry);
+	rb_insert(&logger->ring_buff, &new_entry);
+
+	return false;
 }
 
-CellDataEntry_t *cell_data_log_get_last(void)
+CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 {
-	return (CellDataEntry_t *)rb_get_head(&cell_log_ring_buff);
+	if (logger == NULL) {
+		return NULL;
+	}
+
+	return rb_get_head(&logger->ring_buff);
 }
 
-void cell_data_log_get_last_n(size_t n, CellDataEntry_t *out_buffer)
+bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
+			      CellDataEntry_t *out_buffer)
 {
+	if (logger == NULL) {
+		return true;
+	}
+
 	if (n > NUM_OF_READINGS) {
 		n = NUM_OF_READINGS;
 	}
 
-	rb_get_last_n(&cell_log_ring_buff, out_buffer, n);
+	rb_get_last_n(&logger->ring_buff, out_buffer, n);
+	return false;
 }
 
-void print_latest_cell_data_log(void)
+void print_latest_cell_data_log(const BMSLogger *logger)
 {
-	CellDataEntry_t *latest_entry = cell_data_log_get_last();
+	if (logger == NULL) {
+		printf("Logger not initialized!!");
+		return;
+	}
+
+	const CellDataEntry_t *latest_entry =
+		(const CellDataEntry_t *)cell_data_log_get_last(logger);
 
 	if (latest_entry == NULL) {
 		printf("No data available!!\r\n");
@@ -80,7 +90,7 @@ void print_latest_cell_data_log(void)
 	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
 		int cell_count = (chip_num % 2 == 0) ? NUM_CELLS_ALPHA :
 						       NUM_CELLS_BETA;
-		printf("Chip %d (%s):\n", chip_num,
+		printf("Chip %d (%s):\r\n", chip_num,
 		       (chip_num % 2 == 0) ? "Alpha" : "Beta");
 
 		for (int cell = 0; cell < cell_count; cell++) {
@@ -93,14 +103,22 @@ void print_latest_cell_data_log(void)
 	}
 }
 
-void print_last_n_cell_data_logs(size_t n)
+void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 {
+	if (logger == NULL) {
+		printf("Logger not initialized!!");
+		return;
+	}
+
 	if (n > NUM_OF_READINGS) {
 		n = NUM_OF_READINGS;
 	}
 
 	CellDataEntry_t log_entries[n];
-	rb_get_last_n(&cell_log_ring_buff, log_entries, n);
+	if (cell_data_log_get_last_n(logger, n, log_entries)) {
+		printf("Error retrieving log entries!\r\n");
+		return;
+	}
 
 	printf("Printing Last %zu Cell Data Logs:\r\n", n);
 

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -8,11 +8,12 @@
 extern TIM_HandleTypeDef htim2;
 
 struct BMSLogger {
+	bool is_initialized;
 	ringbuf_t ring_buff;
 	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
 };
 
-static BMSLogger bms_logger;
+static BMSLogger bms_logger = { .is_initialized = false };
 
 BMSLogger *getLogger(void)
 {
@@ -31,10 +32,17 @@ bool cell_data_logger_init(BMSLogger *logger)
 		return true;
 	}
 
+	if (logger->is_initialized) {
+		printf("WARNING: Logger is already initialized!\r\n");
+		return true;
+	}
+
 	memset(logger, 0, sizeof(BMSLogger));
 
 	rb_init(&logger->ring_buff, logger->cell_data_storage, NUM_OF_READINGS,
 		sizeof(CellDataEntry_t));
+
+	logger->is_initialized = true;
 
 	return false;
 }

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -72,7 +72,7 @@ bool cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 		return true;
 	}
 
-	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TICKS) != osOK) {
+	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		return true;
 	}
@@ -114,7 +114,7 @@ CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 		return NULL;
 	}
 
-	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TICKS) != osOK) {
+	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		return NULL;
 	}
@@ -142,7 +142,7 @@ bool cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 		return true;
 	}
 
-	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TICKS) != osOK) {
+	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		return true;
 	}

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -77,21 +77,63 @@ int cell_data_logger_init(struct BMSLogger *logger)
 }
 
 /**
- * @brief Assigns a timestamp to the voltage measurement field of a cell data entry.
- * @param entry Pointer to the CellDataEntry_t structure to update.
+ * @brief Assigns a voltage timestamp to the current log entry. 
+ * @param logger Pointer to the BMSLogger instance.
+ * @return 0 on success, -1 on failure.
  */
-void cell_data_set_voltage_timestamp(CellDataEntry_t *entry)
+int cell_data_logger_timestamp_voltage(struct BMSLogger *logger)
 {
-	entry->cell_voltage_timestamp = get_us_timestamp();
+	assert(logger != NULL);
+
+	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
+		printf("ERROR: Failed to aquire data logging mutex!\r\n");
+		return -1;
+	}
+
+	if (!logger->first_timestamp_set) {
+		size_t next_idx = (logger->ring_buff.head_idx + 1) %
+				  logger->ring_buff.size;
+
+		logger->latest_entry = &logger->cell_data_storage[next_idx];
+
+		logger->first_timestamp_set = true;
+	}
+
+	assert(logger->latest_entry != NULL);
+	logger->latest_entry->cell_voltage_timestamp = get_us_timestamp();
+
+	osMutexRelease(logger->mutex);
+	return 0;
 }
 
 /**
-  * @brief Assigns a timestamp to the temperature measurement field of a cell data entry.
-  * @param entry Pointer to the CellDataEntry_t structure to update.
-  */
-void cell_data_set_therm_timestamp(CellDataEntry_t *entry)
+ * @brief Assigns a temperature timestamp to the current log entry.
+ * @param logger Pointer to the BMSLogger instance.
+ * @return 0 on success, -1 on failure.
+ */
+int cell_data_logger_timestamp_therms(struct BMSLogger *logger)
 {
-	entry->cell_temperature_timestamp = get_us_timestamp();
+	assert(logger != NULL);
+
+	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
+		printf("ERROR: Failed to aquire data logging mutex!\r\n");
+		return -1;
+	}
+
+	if (!logger->first_timestamp_set) {
+		size_t next_idx = (logger->ring_buff.head_idx + 1) %
+				  logger->ring_buff.size;
+
+		logger->latest_entry = &logger->cell_data_storage[next_idx];
+
+		logger->first_timestamp_set = true;
+	}
+
+	assert(logger->latest_entry != NULL);
+	logger->latest_entry->cell_temperature_timestamp = get_us_timestamp();
+
+	osMutexRelease(logger->mutex);
+	return 0;
 }
 
 /**
@@ -101,19 +143,22 @@ void cell_data_set_therm_timestamp(CellDataEntry_t *entry)
  * 
  * @param logger Pointer to the BMSLogger instance managing the ring buffer.
  * @param bms_data Pointer to the BMS data structure containing cell voltages and temperatures.
- * @param entry Pointer to a CellDataEntry_t structure that holds the measurement data.
  * @return 0 on success, -1 on failure.
  */
-int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data,
-			      CellDataEntry_t *entry)
+int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data)
 {
 	int status = -1;
 	assert(logger != NULL);
 	assert(bms_data != NULL);
-	assert(entry != NULL);
 
 	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
+		goto exit;
+	}
+
+	if (logger->latest_entry == NULL) {
+		printf("ERROR: No timestamped entry available!\r\n");
+		osMutexRelease(logger->mutex);
 		goto exit;
 	}
 
@@ -121,20 +166,22 @@ int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data,
 		int cell_count = get_num_cells(&bms_data->chip_data[chip_num]);
 
 		for (int cell = 0; cell < cell_count; cell++) {
-			entry->cell_voltages[chip_num][cell] =
+			logger->latest_entry->cell_voltages[chip_num][cell] =
 				bms_data->chip_data[chip_num]
 					.cell_voltages[cell];
 
-			entry->cell_temperatures[chip_num][cell] =
+			logger->latest_entry->cell_temperatures[chip_num][cell] =
 				bms_data->chip_data[chip_num].cell_temp[cell];
 		}
 	}
 
-	rb_insert(&logger->ring_buff, entry);
+	rb_insert(&logger->ring_buff, logger->latest_entry);
+	logger->latest_entry = NULL;
+	logger->first_timestamp_set = false;
 
 	status = 0;
-
 	osMutexRelease(logger->mutex);
+	return status;
 
 exit:
 	return status;

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -30,7 +30,7 @@ static inline uint32_t get_us_timestamp(void)
  */
 static CellDataEntry_t *get_writable_log_entry(struct BMSLogger *logger)
 {
-	assert(logger != NULL);
+	assert(logger);
 
 	size_t next_idx = logger->ring_buff.head_idx;
 
@@ -46,7 +46,7 @@ static CellDataEntry_t *get_writable_log_entry(struct BMSLogger *logger)
  */
 static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
 {
-	assert(entry != NULL);
+	assert(entry);
 
 	printf("\r\n--- Log Entry %u ---\r\n", entry_idx + 1);
 	printf("Voltage Measurement Timestamp: %lu µs\r\n",
@@ -75,7 +75,7 @@ static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
  */
 int cell_data_logger_init(struct BMSLogger *logger)
 {
-	assert(logger != NULL);
+	assert(logger);
 
 	memset(logger, 0, sizeof(struct BMSLogger));
 
@@ -99,7 +99,7 @@ int cell_data_logger_init(struct BMSLogger *logger)
  */
 int cell_data_logger_timestamp_voltage(struct BMSLogger *logger)
 {
-	assert(logger != NULL);
+	assert(logger);
 
 	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
 		printf("ERROR: Failed to acquire data logging mutex!\r\n");
@@ -125,7 +125,7 @@ int cell_data_logger_timestamp_voltage(struct BMSLogger *logger)
  */
 int cell_data_logger_timestamp_therms(struct BMSLogger *logger)
 {
-	assert(logger != NULL);
+	assert(logger);
 
 	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
 		printf("ERROR: Failed to acquire data logging mutex!\r\n");
@@ -156,8 +156,8 @@ int cell_data_logger_timestamp_therms(struct BMSLogger *logger)
 int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data)
 {
 	int status = -1;
-	assert(logger != NULL);
-	assert(bms_data != NULL);
+	assert(logger);
+	assert(bms_data);
 
 	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
 		printf("ERROR: Failed to acquire data logging mutex!\r\n");
@@ -205,7 +205,7 @@ int cell_data_log_get_last_n(const struct BMSLogger *logger, size_t n,
 			     CellDataEntry_t *out_buffer)
 {
 	int status = -1;
-	assert(logger != NULL);
+	assert(logger);
 
 	if (n > logger->ring_buff.curr_elements) {
 		printf("ERROR: Not enough logs available!\r\n");
@@ -236,7 +236,7 @@ exit:
 int print_last_n_cell_data_logs(const struct BMSLogger *logger, size_t n)
 {
 	int status = -1;
-	assert(logger != NULL);
+	assert(logger);
 
 	CellDataEntry_t log_entries[n];
 

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -4,6 +4,7 @@
 #include "stm32f4xx_hal.h"
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 
 extern TIM_HandleTypeDef htim2;
 
@@ -18,20 +19,9 @@ uint32_t get_us_timestamp(void)
 	return __HAL_TIM_GET_COUNTER(&htim2);
 }
 
-static int get_logger_status(const BMSLogger *logger)
-{
-	if (logger == NULL) {
-		printf("ERROR: Logger is NULL, cannot initialize!\r\n");
-		return -1;
-	} else {
-		return 0;
-	}
-}
-
 int cell_data_logger_init(BMSLogger *logger)
 {
-	if (!get_logger_status(logger))
-		return -1;
+	assert(logger != NULL);
 
 	memset(logger, 0, sizeof(BMSLogger));
 
@@ -49,13 +39,8 @@ int cell_data_logger_init(BMSLogger *logger)
 
 int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 {
-	if (!get_logger_status(logger))
-		return -1;
-
-	if (bms_data == NULL) {
-		printf("ERROR: BMS data is NULL, cannot log data!\r\n");
-		return -1;
-	}
+	assert(logger != NULL);
+	assert(bms_data != NULL);
 
 	if (osMutexAcquire(logger->mutex, LOGGER_MUTEX_WAIT_TIME) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
@@ -91,8 +76,7 @@ int cell_data_log_measurement(BMSLogger *logger, acc_data_t *bms_data)
 
 CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 {
-	if (!get_logger_status(logger))
-		return NULL;
+	assert(logger != NULL);
 
 	if (logger->ring_buff.curr_elements == 0) {
 		printf("ERROR: No logs available!\r\n");
@@ -114,8 +98,7 @@ CellDataEntry_t *cell_data_log_get_last(const BMSLogger *logger)
 int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 			     CellDataEntry_t *out_buffer)
 {
-	if (!get_logger_status(logger))
-		return -1;
+	assert(logger != NULL);
 
 	if (n > NUM_OF_READINGS) {
 		printf("ERROR: Requested logs exceed limit!\r\n");
@@ -141,8 +124,7 @@ int cell_data_log_get_last_n(const BMSLogger *logger, size_t n,
 
 void print_latest_cell_data_log(const BMSLogger *logger)
 {
-	if (!get_logger_status(logger))
-		return;
+	assert(logger != NULL);
 
 	const CellDataEntry_t *latest_entry =
 		(const CellDataEntry_t *)cell_data_log_get_last(logger);
@@ -171,8 +153,7 @@ void print_latest_cell_data_log(const BMSLogger *logger)
 
 void print_last_n_cell_data_logs(const BMSLogger *logger, size_t n)
 {
-	if (!get_logger_status(logger))
-		return;
+	assert(logger != NULL);
 
 	if (n > NUM_OF_READINGS) {
 		printf("ERROR: Requested logs exceed limit!\r\n");

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -1,0 +1,25 @@
+#include "cell_data_logging.h"
+#include "analyzer.h"
+#include "stm32f4xx_hal.h"
+#include <stdio.h>
+#include <string.h>
+
+// For timestamps
+extern TIM_HandleTypeDef htim2;
+
+// Ring buffer
+static ringbuf_t cell_log_ring_buff;
+
+// Storage buffer for cell data
+static CellDataEntry_t cell_data_storage[NUM_OF_READINGS] = { 0 };
+
+static uint32_t get_us_timestamp(void)
+{
+	return __HAL_TIM_GET_COUNTER(&htim2);
+}
+
+void cell_data_logger_init(void)
+{
+	rb_init(&cell_log_ring_buff, cell_data_storage, NUM_OF_READINGS,
+		sizeof(CellDataEntry_t));
+}

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -47,7 +47,7 @@ static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
  * @brief Retrieves the current timestamp in microseconds from TIM2.
  * @return The current timestamp in microseconds.
  */
-uint32_t get_us_timestamp(void)
+static uint32_t get_us_timestamp(void)
 {
 	return __HAL_TIM_GET_COUNTER(&htim2);
 }
@@ -77,40 +77,60 @@ int cell_data_logger_init(struct BMSLogger *logger)
 }
 
 /**
- * @brief Logs a new measurement and inserts it in the ring buffer.
- * @param logger Pointer to the logger instance.
- * @param bms_data Pointer to the BMS data containing chip cell voltages and temperatures.
+ * @brief Assigns a timestamp to the voltage measurement field of a cell data entry.
+ * @param entry Pointer to the CellDataEntry_t structure to update.
+ */
+void cell_data_set_voltage_timestamp(CellDataEntry_t *entry)
+{
+	entry->cell_voltage_timestamp = get_us_timestamp();
+}
+
+/**
+  * @brief Assigns a timestamp to the temperature measurement field of a cell data entry.
+  * @param entry Pointer to the CellDataEntry_t structure to update.
+  */
+void cell_data_set_therm_timestamp(CellDataEntry_t *entry)
+{
+	entry->cell_temperature_timestamp = get_us_timestamp();
+}
+
+/**
+ * @brief Logs a new measurement and inserts it into the ring buffer.
+ * 
+ * @note The user is responsible for ensuring the timestamps are set before calling this function.
+ * 
+ * @param logger Pointer to the BMSLogger instance managing the ring buffer.
+ * @param bms_data Pointer to the BMS data structure containing cell voltages and temperatures.
+ * @param entry Pointer to a CellDataEntry_t structure that holds the measurement data.
  * @return 0 on success, -1 on failure.
  */
-int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data)
+int cell_data_log_measurement(struct BMSLogger *logger, acc_data_t *bms_data,
+			      CellDataEntry_t *entry)
 {
 	int status = -1;
 	assert(logger != NULL);
 	assert(bms_data != NULL);
+	assert(entry != NULL);
 
 	if (osMutexAcquire(logger->mutex, osWaitForever) != osOK) {
 		printf("ERROR: Failed to aquire data logging mutex!\r\n");
 		goto exit;
 	}
 
-	CellDataEntry_t new_entry;
-
-	memset(&new_entry, 0, sizeof(CellDataEntry_t));
-
 	for (int chip_num = 0; chip_num < NUM_CHIPS; chip_num++) {
 		int cell_count = get_num_cells(&bms_data->chip_data[chip_num]);
 
 		for (int cell = 0; cell < cell_count; cell++) {
-			new_entry.cell_voltages[chip_num][cell] =
+			entry->cell_voltages[chip_num][cell] =
 				bms_data->chip_data[chip_num]
 					.cell_voltages[cell];
 
-			new_entry.cell_temperatures[chip_num][cell] =
+			entry->cell_temperatures[chip_num][cell] =
 				bms_data->chip_data[chip_num].cell_temp[cell];
 		}
 	}
 
-	rb_insert(&logger->ring_buff, &new_entry);
+	rb_insert(&logger->ring_buff, entry);
 
 	status = 0;
 

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -15,19 +15,6 @@
 extern TIM_HandleTypeDef htim2;
 
 /**
- * @struct BMSLogger
- * @brief Internal structure to manage logging system.
- */
-struct BMSLogger {
-	ringbuf_t ring_buff;
-	CellDataEntry_t cell_data_storage[NUM_OF_READINGS];
-	osMutexId_t mutex;
-};
-
-/* Global instance of BMSLogger */
-static struct BMSLogger bms_logger;
-
-/**
  * @brief Prints a single cell data entry.
  * @param entry Pointer to the cell data entry to print.
  * @param entry_idx Index of the entry.
@@ -63,15 +50,6 @@ static void print_cell_data(const CellDataEntry_t *entry, size_t entry_idx)
 uint32_t get_us_timestamp(void)
 {
 	return __HAL_TIM_GET_COUNTER(&htim2);
-}
-
-/**
- * @brief Retrieves the global instance of the BMSLogger.
- * @return Pointer to the global `BMSLogger` instance.
- */
-struct BMSLogger *get_logger(void)
-{
-	return &bms_logger;
 }
 
 /**

--- a/Core/Src/cell_data_logging.c
+++ b/Core/Src/cell_data_logging.c
@@ -14,13 +14,6 @@ struct BMSLogger {
 	osMutexId_t mutex;
 };
 
-static BMSLogger bms_logger = { .is_initialized = false };
-
-BMSLogger *get_logger(void)
-{
-	return &bms_logger;
-}
-
 uint32_t get_us_timestamp(void)
 {
 	return __HAL_TIM_GET_COUNTER(&htim2);

--- a/Core/Src/segment.c
+++ b/Core/Src/segment.c
@@ -194,12 +194,13 @@ void segment_retrieve_data(acc_data_t *bmsdata)
 	// read from ADC convs
 	read_filtered_voltage_registers(bmsdata->chips);
 
+	// Timestamp when voltage measured
 	bmsdata->voltage_timestamp = get_us_timestamp();
 
 	// read all therms using AUX 2
 	adc_and_read_aux2_registers(bmsdata->chips);
 
-	// Timestamp when temperature was
+	// Timestamp when therms measured
 	bmsdata->temperature_timestamp = get_us_timestamp();
 }
 

--- a/Core/Src/segment.c
+++ b/Core/Src/segment.c
@@ -4,7 +4,6 @@
 #include "analyzer.h"
 #include "c_utils.h"
 #include "serialPrintResult.h"
-#include "cell_data_logging.h"
 
 #define T_READY 10 /* microseconds*/
 #define T_IDLE	4.3 /* milliseconds, minimum. typ is 5.5, max is 6.7 */
@@ -194,14 +193,8 @@ void segment_retrieve_data(acc_data_t *bmsdata)
 	// read from ADC convs
 	read_filtered_voltage_registers(bmsdata->chips);
 
-	// Timestamp when voltage measured
-	bmsdata->voltage_timestamp = get_us_timestamp();
-
 	// read all therms using AUX 2
 	adc_and_read_aux2_registers(bmsdata->chips);
-
-	// Timestamp when therms measured
-	bmsdata->temperature_timestamp = get_us_timestamp();
 }
 
 void segment_retrieve_debug_data(acc_data_t *bmsdata)

--- a/Core/Src/segment.c
+++ b/Core/Src/segment.c
@@ -194,8 +194,13 @@ void segment_retrieve_data(acc_data_t *bmsdata)
 	// read from ADC convs
 	read_filtered_voltage_registers(bmsdata->chips);
 
+	bmsdata->voltage_timestamp = get_us_timestamp();
+
 	// read all therms using AUX 2
 	adc_and_read_aux2_registers(bmsdata->chips);
+
+	// Timestamp when temperature was
+	bmsdata->temperature_timestamp = get_us_timestamp();
 }
 
 void segment_retrieve_debug_data(acc_data_t *bmsdata)

--- a/Core/Src/segment.c
+++ b/Core/Src/segment.c
@@ -110,9 +110,6 @@ void segment_init(acc_data_t *bmsdata)
 	write_config_regs(bmsdata->chips);
 
 	start_c_adc_conv();
-
-	// Initializes data logging ring buffer
-	cell_data_logger_init();
 }
 
 void segment_adc_comparison(acc_data_t *bmsdata)
@@ -199,10 +196,8 @@ void segment_retrieve_data(acc_data_t *bmsdata)
 
 	// read all therms using AUX 2
 	adc_and_read_aux2_registers(bmsdata->chips);
-
-	// Logs cell data
-	cell_data_log_measurement(bmsdata);
 }
+
 void segment_retrieve_debug_data(acc_data_t *bmsdata)
 {
 	// poll stuff like vref, etc.

--- a/Core/Src/segment.c
+++ b/Core/Src/segment.c
@@ -4,6 +4,7 @@
 #include "analyzer.h"
 #include "c_utils.h"
 #include "serialPrintResult.h"
+#include "cell_data_logging.h"
 
 #define T_READY 10 /* microseconds*/
 #define T_IDLE	4.3 /* milliseconds, minimum. typ is 5.5, max is 6.7 */
@@ -109,6 +110,9 @@ void segment_init(acc_data_t *bmsdata)
 	write_config_regs(bmsdata->chips);
 
 	start_c_adc_conv();
+
+	// Initializes data logging ring buffer
+	cell_data_logger_init();
 }
 
 void segment_adc_comparison(acc_data_t *bmsdata)
@@ -195,6 +199,9 @@ void segment_retrieve_data(acc_data_t *bmsdata)
 
 	// read all therms using AUX 2
 	adc_and_read_aux2_registers(bmsdata->chips);
+
+	// Logs cell data
+	cell_data_log_measurement(bmsdata);
 }
 void segment_retrieve_debug_data(acc_data_t *bmsdata)
 {

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ Core/Src/stateMachine.c \
 Core/Src/can_handler.c \
 Core/Src/can_messages.c \
 Core/Src/shep_tasks.c \
+Core/Src/cell_data_logging.c \
 Core/Src/stm32f4xx_it.c \
 Core/Src/stm32f4xx_hal_msp.c \
 Drivers/Embedded-Base/platforms/stm32f405/src/can.c \


### PR DESCRIPTION
## Changes

- Added cell data logging functionality using a ring buffer.
- Implemented timestamping for cell data using TIM2 in microseconds.
- Stored the last N measurements in a static array.
- Provided functions for retrieving data: last log, last n logs.
- Implemented functions to view logs on serial terminal.

## Notes

The buffer size can be adjusted in the header file to store more readings.

## Test Cases

- Test A: Fake BMS Data on STM32F4 Nucleo
The logging functionality was first tested on an STM32 Nucleo board using fake BMS data. Simulated cell voltages and temperatures were logged, retrieved, and verified using serial printouts. 
- Test B: Real BMS Data on Shepherd BMS Master Board
The logging functionality was tested on the Shepherd BMS Master Board, configured with one chip Alpha. The inputs were connected to a PSU to simulate real cell voltages.

## To Do

- Validate logging behavior with real BMS data instead of test cases.
- Validate functionality with additional chips and segments.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #175 )
