### PR TITLE
Add PEC error counting and CAN message transmission

### DIFF
--- a/Core/Inc/can_handler.h
+++ b/Core/Inc/can_handler.h
@@ -42,6 +42,8 @@
 
 #define OVERFLOW_CANID	   0x6F1
 #define OVERFLOW_SIZE	   6
+#define PEC_ERROR_CANID	   0x6F2
+#define PEC_ERROR_SIZE	   3
 #define ALPHA_CELL_CANID   0x6FA
 #define BETA_CELL_CANID	   0x6FB
 #define CELL_MSG_SIZE	   7

--- a/Core/Inc/can_messages.h
+++ b/Core/Inc/can_messages.h
@@ -215,4 +215,12 @@ void send_alpha_status_b_message(float v_res, uint8_t chip, float vref2,
 				 float v_analog, float v_digital,
 				 stc_ *flt_reg);
 
+/**
+ * @brief Sends a CAN message containing the PEC error count for a specific chip.
+ *
+ * @param chip_num The index of the chip that reported PEC errors.
+ * @param pec_count The total number of PEC errors detected for the specified chip.
+ */
+void send_pec_error_message(uint8_t chip_num, uint16_t pec_count);
+
 #endif

--- a/Core/Src/adi_interaction.c
+++ b/Core/Src/adi_interaction.c
@@ -16,17 +16,17 @@ static void count_pec_errors(cell_asic chips[NUM_CHIPS])
 {
 	for (uint8_t chip = 0U; chip < NUM_CHIPS; chip++) {
 		uint16_t pec_error_count =
-					     (uint16_t)(chips[chip].cccrc.cfgr_pec +
-					     chips[chip].cccrc.cell_pec +
-					     chips[chip].cccrc.acell_pec +
-					     chips[chip].cccrc.scell_pec +
-					     chips[chip].cccrc.fcell_pec +
-					     chips[chip].cccrc.aux_pec +
-					     chips[chip].cccrc.raux_pec +
-					     chips[chip].cccrc.stat_pec +
-					     chips[chip].cccrc.comm_pec +
-					     chips[chip].cccrc.pwm_pec +
-					     chips[chip].cccrc.sid_pec);
+			(uint16_t)(chips[chip].cccrc.cfgr_pec +
+				   chips[chip].cccrc.cell_pec +
+				   chips[chip].cccrc.acell_pec +
+				   chips[chip].cccrc.scell_pec +
+				   chips[chip].cccrc.fcell_pec +
+				   chips[chip].cccrc.aux_pec +
+				   chips[chip].cccrc.raux_pec +
+				   chips[chip].cccrc.stat_pec +
+				   chips[chip].cccrc.comm_pec +
+				   chips[chip].cccrc.pwm_pec +
+				   chips[chip].cccrc.sid_pec);
 
 		if (pec_error_count > 0) {
 			printf("PEC Error: Chip %u, Count: %u\n", chip + 1,

--- a/Core/Src/adi_interaction.c
+++ b/Core/Src/adi_interaction.c
@@ -2,6 +2,44 @@
 #include "adBms6830CmdList.h"
 #include "adBms6830GenericType.h"
 #include "mcuWrapper.h"
+#include "can_messages.h"
+
+/**
+ * @brief Count and reset PEC errors for all chips, then send a CAN message if needed.
+ *
+ * This function iterates through all chips, accumulates the PEC (Packet Error Code) 
+ * error count, resets the PEC error counters, and sends a CAN message if any errors exist.
+ *
+ * @param chips Array of chips containing PEC error data.
+ */
+static void count_pec_errors(cell_asic chips[NUM_CHIPS])
+{
+	uint16_t pec_error_count = 0U;
+
+	for (uint8_t chip = 0U; chip < NUM_CHIPS; chip++) {
+		pec_error_count = (uint16_t)(chips[chip].cccrc.cmd_cntr +
+					     chips[chip].cccrc.cfgr_pec +
+					     chips[chip].cccrc.cell_pec +
+					     chips[chip].cccrc.acell_pec +
+					     chips[chip].cccrc.scell_pec +
+					     chips[chip].cccrc.fcell_pec +
+					     chips[chip].cccrc.aux_pec +
+					     chips[chip].cccrc.raux_pec +
+					     chips[chip].cccrc.stat_pec +
+					     chips[chip].cccrc.comm_pec +
+					     chips[chip].cccrc.pwm_pec +
+					     chips[chip].cccrc.sid_pec);
+
+		if (pec_error_count > 0) {
+			printf("PEC Error: Chip %u, Count: %u\n", chip,
+			       pec_error_count);
+
+			send_pec_error_message(chip, pec_error_count);
+		}
+
+		memset(&(chips[chip].cccrc), 0, sizeof(chips[chip].cccrc));
+	}
+}
 
 /**
  * @brief Set a bit in a uint16
@@ -193,38 +231,7 @@ void read_adbms_data(cell_asic chips[NUM_CHIPS], uint8_t command[2], TYPE type,
 		adBmsReadData(NUM_CHIPS, &chips[chip], command, type, group);
 	}
 
-	// Count PEC errors
-	uint32_t pec_error_count = 0;
-	for (uint8_t chip = 0; chip < NUM_CHIPS; chip++) {
-		// Yes, they did separate every PEC as if that mattered.
-		pec_error_count +=
-			chips[chip].cccrc.cfgr_pec + chips[chip].cccrc.sid_pec +
-			chips[chip].cccrc.cell_pec +
-			chips[chip].cccrc.acell_pec +
-			chips[chip].cccrc.scell_pec +
-			chips[chip].cccrc.fcell_pec +
-			chips[chip].cccrc.aux_pec + chips[chip].cccrc.raux_pec +
-			chips[chip].cccrc.stat_pec +
-			chips[chip].cccrc.comm_pec + chips[chip].cccrc.pwm_pec;
-
-		if (pec_error_count > 0) {
-			printf("PEC COUNT: %ld | Chip: %d | CMD: %d\n",
-			       pec_error_count, chip, type);
-		}
-
-		chips[chip].cccrc.cfgr_pec = 0;
-		chips[chip].cccrc.sid_pec = 0;
-		chips[chip].cccrc.cell_pec = 0;
-		chips[chip].cccrc.acell_pec = 0;
-		chips[chip].cccrc.scell_pec = 0;
-		chips[chip].cccrc.fcell_pec = 0;
-		chips[chip].cccrc.aux_pec = 0;
-		chips[chip].cccrc.raux_pec = 0;
-		chips[chip].cccrc.stat_pec = 0;
-		chips[chip].cccrc.comm_pec = 0;
-		chips[chip].cccrc.pwm_pec = 0;
-	}
-	pec_error_count = 0;
+	count_pec_errors(chips);
 }
 
 // --- BEGIN WRITE COMMANDS ---

--- a/Core/Src/adi_interaction.c
+++ b/Core/Src/adi_interaction.c
@@ -8,17 +8,15 @@
  * @brief Count and reset PEC errors for all chips, then send a CAN message if needed.
  *
  * This function iterates through all chips, accumulates the PEC (Packet Error Code) 
- * error count, resets the PEC error counters, and sends a CAN message if any errors exist.
+ * error count, resets the PEC error counter and Command counter, then sends a CAN message if any errors exist.
  *
  * @param chips Array of chips containing PEC error data.
  */
 static void count_pec_errors(cell_asic chips[NUM_CHIPS])
 {
-	uint16_t pec_error_count = 0U;
-
 	for (uint8_t chip = 0U; chip < NUM_CHIPS; chip++) {
-		pec_error_count = (uint16_t)(chips[chip].cccrc.cmd_cntr +
-					     chips[chip].cccrc.cfgr_pec +
+		uint16_t pec_error_count =
+					     (uint16_t)(chips[chip].cccrc.cfgr_pec +
 					     chips[chip].cccrc.cell_pec +
 					     chips[chip].cccrc.acell_pec +
 					     chips[chip].cccrc.scell_pec +

--- a/Core/Src/adi_interaction.c
+++ b/Core/Src/adi_interaction.c
@@ -31,10 +31,10 @@ static void count_pec_errors(cell_asic chips[NUM_CHIPS])
 					     chips[chip].cccrc.sid_pec);
 
 		if (pec_error_count > 0) {
-			printf("PEC Error: Chip %u, Count: %u\n", chip,
+			printf("PEC Error: Chip %u, Count: %u\n", chip + 1,
 			       pec_error_count);
 
-			send_pec_error_message(chip, pec_error_count);
+			send_pec_error_message(chip + 1, pec_error_count);
 		}
 
 		memset(&(chips[chip].cccrc), 0, sizeof(chips[chip].cccrc));

--- a/Core/Src/can_messages.c
+++ b/Core/Src/can_messages.c
@@ -726,3 +726,31 @@ void send_alpha_status_b_message(float v_res, uint8_t chip, float vref2,
 	queue_can_msg(msg);
 	// clang-format on
 }
+
+/**
+ * @brief Sends a CAN message containing the PEC error count for a specific chip.
+ *
+ * @param chip_num The index of the chip that reported PEC errors.
+ * @param pec_count The total number of PEC errors detected for the specified chip.
+ */
+void send_pec_error_message(uint8_t chip_num, uint16_t pec_count)
+{
+	struct __attribute__((__packed__)) {
+		uint16_t pec_error_count;
+		uint8_t chip_number;
+	} pec_data;
+
+	pec_data.chip_number = chip_num;
+	pec_data.pec_error_count = pec_count;
+
+	endian_swap(&pec_data.pec_error_count,
+		    sizeof(pec_data.pec_error_count));
+
+	can_msg_t msg;
+	msg.id = PEC_ERROR_CANID;
+	msg.len = PEC_ERROR_SIZE;
+
+	memcpy(&msg.data, &pec_data, sizeof(pec_data));
+
+	queue_can_msg(msg);
+}


### PR DESCRIPTION
## Changes

- Implemented PEC error counting function.
- Added a function to send PEC error counts over CAN.
- Removed previous PEC counter attempts.

## Test Cases

- 

## To Do

- Test PEC error counting and CAN transmission.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #185 
