### PR TITLE
155 24a charge current limit calculations

### DIFF
--- a/Core/Inc/analyzer.h
+++ b/Core/Inc/analyzer.h
@@ -83,8 +83,9 @@ void calc_dcl(acc_data_t *bmsdata);
 void calc_cont_dcl(acc_data_t *bmsdata);
 
 /**
- * @brief Calculate the continuous charging current limit based on cell temperatures and a cell temp to CCL lookup table.
- * 
+ * @brief Calculate continuous charge current limit (CCL) using linear derating from max cell temperature and voltage.
+ *
+ * @param bmsdata Pointer to BMS data structure.
  */
 void calc_cont_ccl(acc_data_t *bmsdata);
 

--- a/Core/Inc/bmsConfig.h
+++ b/Core/Inc/bmsConfig.h
@@ -43,6 +43,10 @@
 #define MAX_CELL_TEMP	60 /* Celsius (rules) */
 #define TYP_IMPDNCE	0.015 /* Ohms, DC, 50% SoC */
 
+// Pack Limits
+#define MAX_PACK_CHG_CURR \
+	30 /* Pack-level charge limit: (13.5A - 3.5A margin) × 3 cells in parallel */
+
 // ADBMS6830 limits
 #define MAX_CHIP_TEMP 60
 

--- a/Core/Inc/bmsConfig.h
+++ b/Core/Inc/bmsConfig.h
@@ -45,7 +45,7 @@
 
 // Pack Limits
 #define MAX_PACK_CHG_CURR \
-	30 /* Pack-level charge limit: (13.5A - 3.5A margin) × 3 cells in parallel */
+	30 /* Pack-level charge limit: (MAX_CHG_CURR - 3.5A margin) × 3 cells in parallel */
 
 // ADBMS6830 limits
 #define MAX_CHIP_TEMP 60

--- a/Core/Src/analyzer.c
+++ b/Core/Src/analyzer.c
@@ -48,22 +48,6 @@ const uint8_t TEMP_TO_DCL[14] =
 };
 
 /**
- * @brief Mapping Cell temperatue to the charge current limit based on the
- *      temperature charge limit curve profile of the Samsung 186500 INR
- *      in the Orion BMS software utility app
- *
- * @note Units are in Amps and indicies are in (degrees C)/5, stops at 65C
- * @note Limit should be *interpolated* from these values (i.e. if we are
- *      at 27C, we should take the limit that is halfway between 25C and 30C)
- *
- */
-const uint8_t TEMP_TO_CCL[14] =
-{
-	0, 25, 25, 25, 25, 25, 25, 25,
-	20, 15, 10, 5, 1, 1
-};
-
-/**
  * @brief Lookup table for State of Charge
  *
  * @note each index covers 0.1V increase (voltage range is 2.9V - 4.2V, deltaV = 1.3V, 
@@ -523,19 +507,23 @@ void calcCCL(acc_data_t *bmsdata)
 //TODO: Change for P45B electrical characteristics.
 void calc_cont_ccl(acc_data_t *bmsdata)
 {
-	uint8_t min_res_index =
-		(bmsdata->min_temp.val - MIN_TEMP) /
-		5; /* resistance LUT increments by 5C for each index */
-	uint8_t max_res_index = (bmsdata->max_temp.val - MIN_TEMP) / 5;
+	float max_temp = bmsdata->max_temp.val;
+	float max_cell_voltage = bmsdata->max_voltage.val;
 
-	if (TEMP_TO_CCL[min_res_index] < TEMP_TO_CCL[max_res_index]) {
-		bmsdata->cont_CCL = TEMP_TO_CCL[min_res_index];
+	float temp_derate_factor = 0.0f;
+	float cell_volt_derate_factor = 0.0f;
+
+	// Temperature Derating: 0–10°C ramp up, 45–60°C ramp down
+	if (max_temp <= MIN_CHG_TEMP || max_temp >= MAX_CELL_TEMP) {
+		temp_derate_factor = 0.0f;
+	} else if (max_temp < 10.0f) {
+		temp_derate_factor =
+			(max_temp - MIN_CHG_TEMP) / (10.0f - MIN_CHG_TEMP);
+	} else if (max_temp <= 45.0f) {
+		temp_derate_factor = 1.0f;
 	} else {
-		bmsdata->cont_CCL = TEMP_TO_CCL[max_res_index];
-	}
-
-	if (bmsdata->cont_CCL > MAX_CHG_CURR) {
-		bmsdata->cont_CCL = MAX_CHG_CURR;
+		temp_derate_factor =
+			(MAX_CELL_TEMP - max_temp) / (MAX_CELL_TEMP - 45.0f);
 	}
 }
 

--- a/Core/Src/analyzer.c
+++ b/Core/Src/analyzer.c
@@ -512,7 +512,10 @@ void calc_cont_ccl(acc_data_t *bmsdata)
 	float temp_derate_factor = 0.0f;
 	float cell_volt_derate_factor = 0.0f;
 
-	// Temperature Derating: 0–10°C ramp up, 45–60°C ramp down
+	// All cell charge limits were obtained from P45B Datasheet.
+
+	/* Temperature Derating: 0–10°C ramp up, 45–60°C ramp down
+	   10°C and 45°C chosen as safe margins from P45B charge temp limits. */
 	if (max_temp <= MIN_CHG_TEMP || max_temp >= MAX_CELL_TEMP) {
 		temp_derate_factor = 0.0f;
 	} else if (max_temp < 10.0f) {
@@ -522,10 +525,11 @@ void calc_cont_ccl(acc_data_t *bmsdata)
 		temp_derate_factor = 1.0f;
 	} else {
 		temp_derate_factor =
-			(MAX_CELL_TEMP - max_temp) / (MAX_CELL_TEMP - 45.0f);
+			(MAX_CELL_TEMP - max_temp) / (MAX_CELLs_TEMP - 45.0f);
 	}
 
-	// Cell Voltage Derating: 4.15–4.205V ramp down
+	/* Cell Voltage Derating: 4.15–4.205V ramp down
+	   4.15V was chosen to reduce current early and avoid overshooting the max limit. */
 	if (max_cell_voltage >= MAX_CHARGE_VOLT) {
 		cell_volt_derate_factor = 0.0f;
 	} else if (max_cell_voltage > 4.15f) {

--- a/Core/Src/analyzer.c
+++ b/Core/Src/analyzer.c
@@ -525,7 +525,7 @@ void calc_cont_ccl(acc_data_t *bmsdata)
 		temp_derate_factor = 1.0f;
 	} else {
 		temp_derate_factor =
-			(MAX_CELL_TEMP - max_temp) / (MAX_CELLs_TEMP - 45.0f);
+			(MAX_CELL_TEMP - max_temp) / (MAX_CELL_TEMP - 45.0f);
 	}
 
 	/* Cell Voltage Derating: 4.15–4.205V ramp down

--- a/Core/Src/analyzer.c
+++ b/Core/Src/analyzer.c
@@ -504,7 +504,6 @@ void calcCCL(acc_data_t *bmsdata)
 	send_mc_charge_message(bmsdata);
 }
 
-//TODO: Change for P45B electrical characteristics.
 void calc_cont_ccl(acc_data_t *bmsdata)
 {
 	float max_temp = bmsdata->max_temp.val;
@@ -525,6 +524,19 @@ void calc_cont_ccl(acc_data_t *bmsdata)
 		temp_derate_factor =
 			(MAX_CELL_TEMP - max_temp) / (MAX_CELL_TEMP - 45.0f);
 	}
+
+	// Cell Voltage Derating: 4.15–4.205V ramp down
+	if (max_cell_voltage >= MAX_CHARGE_VOLT) {
+		cell_volt_derate_factor = 0.0f;
+	} else if (max_cell_voltage > 4.15f) {
+		cell_volt_derate_factor = (MAX_CHARGE_VOLT - max_cell_voltage) /
+					  (MAX_CHARGE_VOLT - 4.15f);
+	} else {
+		cell_volt_derate_factor = 1.0f;
+	}
+
+	bmsdata->cont_CCL =
+		MAX_CHG_CURR * temp_derate_factor * cell_volt_derate_factor;
 }
 
 void calc_open_cell_voltage(acc_data_t *bmsdata)

--- a/Core/Src/analyzer.c
+++ b/Core/Src/analyzer.c
@@ -539,8 +539,8 @@ void calc_cont_ccl(acc_data_t *bmsdata)
 		cell_volt_derate_factor = 1.0f;
 	}
 
-	bmsdata->cont_CCL =
-		MAX_CHG_CURR * temp_derate_factor * cell_volt_derate_factor;
+	bmsdata->cont_CCL = MAX_PACK_CHG_CURR * temp_derate_factor *
+			    cell_volt_derate_factor;
 }
 
 void calc_open_cell_voltage(acc_data_t *bmsdata)


### PR DESCRIPTION
## Changes

Added linear derating logic for continuous charge current limit (CCL) based on max cell temperature and voltage.

- Temp derates: 0–10°C ramp-up, 45–60°C ramp-down
- Voltage derates: 4.15–4.205 V ramp-down

## Notes

- All limits sourced from P45B datasheet.

## Test Cases

- Tested in C compiler with mocked BMS data to simulate various conditions

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
