### PR TITLE
Charging Detection 24A

### DIFF
--- a/Core/Inc/can_handler.h
+++ b/Core/Inc/can_handler.h
@@ -38,6 +38,8 @@
 #define NOISE_CANID	    0x88
 #define NOISE_SIZE	    6
 #define DEBUG_CANID	    0x702
+#define CHARGER_CANID	    0x1806E5F4
+#define CHARGERBOX_CANID    0x18FF50E5
 
 #define OVERFLOW_CANID	   0x6F1
 #define OVERFLOW_SIZE	   6
@@ -102,7 +104,7 @@ void init_both_can(CAN_HandleTypeDef *hcan1, CAN_HandleTypeDef *hcan2);
 /**
  * @brief Task for sending CAN messages.
  * 
- * @param pv_params CAN_HandleTypeDef for the CAN line that messages will be sent out on.
+ * @param pv_params Pointer to acc_data_t struct containing BMS data
  */
 void vCanDispatch(void *pv_params);
 extern osThreadId_t can_dispatch_handle;

--- a/Core/Inc/compute.h
+++ b/Core/Inc/compute.h
@@ -24,21 +24,6 @@ typedef enum { FAN1, FAN2, FAN3, FAN4, FAN5, FAN6, FANMAX } fan_select_t;
 uint8_t compute_init();
 
 /**
- * @brief sets safeguard bool to check whether charging is enabled or disabled
- *
- * @param is_enabled
- */
-void compute_enable_charging(bool enable_charging);
-
-/**
- * @brief Returns if charger interlock is engaged, indicating charger LV connector is plugged in
- *
- * @return true
- * @return false
- */
-bool compute_charger_connected();
-
-/**
  * @brief Handle any messages received from the charger
  *
  * @param msg

--- a/Core/Inc/datastructs.h
+++ b/Core/Inc/datastructs.h
@@ -155,6 +155,7 @@ typedef struct {
 	uint16_t boost_setting;
 
 	bool is_charger_connected;
+	bool is_charging_enabled;
 
 	osMutexId_t mutex;
 } acc_data_t;

--- a/Core/Inc/stateMachine.h
+++ b/Core/Inc/stateMachine.h
@@ -12,6 +12,14 @@ extern uint16_t crc_error_check;
 #define NUM_FAULTS 9
 
 /**
+ * @brief Called when we receive a message from the charger
+ * 
+ * @param bmsdata
+ * 
+ */
+void charger_message_recieved(acc_data_t *bmsdata);
+
+/**
  * @brief Returns if we want to balance cells during a particular frame
  *
  * @param bmsdata

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -3,6 +3,8 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "datastructs.h"
+#include "stateMachine.h"
 
 #define CAN_MSG_QUEUE_SIZE 50 /* messages */
 
@@ -48,7 +50,7 @@ static uint16_t can2_id_list_standard[4] = {
 
 static uint32_t can2_id_list_extended[2] = {
 	//CANID_X,
-	0x18FF50E5
+	CHARGERBOX_CANID
 };
 
 osStatus_t queue_and_set_flag(osMessageQueueId_t queue, const void *msg_ptr,
@@ -200,11 +202,13 @@ void vCanDispatch(void *pv_params)
 	can_msg_t msg_from_queue;
 	HAL_StatusTypeDef msg_status;
 
+	acc_data_t *bmsdata = (acc_data_t *)pv_params;
+
 	can_t *line;
-#ifdef CHARGING
-	line = can2;
-#endif
-	line = can1;
+	if (bmsdata->is_charger_connected)
+		line = can2;
+	else
+		line = can1;
 
 	for (;;) {
 		osThreadFlagsWait(CAN_DISPATCH_FLAG, osFlagsWaitAny,
@@ -219,7 +223,7 @@ void vCanDispatch(void *pv_params)
 				osDelay(1);
 			}
 
-			msg_status = can_send_msg(can1, &msg_from_queue);
+			msg_status = can_send_msg(line, &msg_from_queue);
 
 			if (msg_status != HAL_OK) {
 				// temporary
@@ -242,12 +246,17 @@ void vCanReceive(void *pv_params)
 {
 	can_msg_t msg;
 
+	acc_data_t *bmsdata = (acc_data_t *)pv_params;
+
 	for (;;) {
 		osThreadFlagsWait(NEW_CAN_MSG_FLAG, osFlagsWaitAny,
 				  osWaitForever);
 		while (osOK ==
 		       osMessageQueueGet(can_inbound_queue, &msg, 0U, 0U)) {
 			switch (msg.id) {
+			case CHARGERBOX_CANID:
+				charger_message_recieved(bmsdata);
+				break;
 			default:
 				break;
 			}

--- a/Core/Src/can_messages.c
+++ b/Core/Src/can_messages.c
@@ -14,8 +14,6 @@
 #define CELL_ID_BITS 4
 #define VA_VD_BITS   10 /* Vanalog and Vdigital internal references */
 
-extern is_charging_enabled;
-
 static unsigned short reverse_short(unsigned short val);
 
 static unsigned short reverse_short(unsigned short val)
@@ -74,7 +72,7 @@ int send_charging_message(uint16_t voltage_to_set, uint16_t current_to_set,
 	charger_msg_data.charger_voltage = voltage_to_set * 10;
 	charger_msg_data.charger_current = current_to_set * 10;
 
-	if (is_charging_enabled) {
+	if (bms_data->is_charging_enabled) {
 		charger_msg_data.charger_control = 0x00; // 0：Start charging.
 	} else {
 		charger_msg_data.charger_control =
@@ -84,7 +82,7 @@ int send_charging_message(uint16_t voltage_to_set, uint16_t current_to_set,
 	charger_msg_data.reserved_1 = 0x00;
 	charger_msg_data.reserved_23 = 0x0000;
 
-	can_msg_t charger_msg = { .id = 0x1806E5F4,
+	can_msg_t charger_msg = { .id = CHARGER_CANID,
 				  .id_is_extended = true,
 				  .len = 8,
 				  .data = { 0 } };
@@ -97,12 +95,12 @@ int send_charging_message(uint16_t voltage_to_set, uint16_t current_to_set,
 	charger_msg.data[2] = charger_msg.data[3];
 	charger_msg.data[3] = temp;
 
-#ifdef CHARGING_ENABLED
-	HAL_StatusTypeDef res = can_send_msg(&can2, &msg);
-	if (res != HAL_OK) {
-		printf("CAN ERROR CODE %X", res);
+	if (bms_data->is_charging_enabled) {
+		HAL_StatusTypeDef res = queue_can_msg(charger_msg);
+		if (res != HAL_OK) {
+			printf("queue_can_msg() ERROR CODE %X", res);
+		}
 	}
-#endif
 
 	return 0;
 }

--- a/Core/Src/compute.c
+++ b/Core/Src/compute.c
@@ -11,8 +11,6 @@
 // #define CHARGING_ENABLED
 
 uint8_t fan_speed;
-bool is_charging_enabled;
-enum { CHARGE_ENABLED, CHARGE_DISABLED };
 uint32_t channel_1_buf;
 
 extern TIM_HandleTypeDef htim1;
@@ -53,20 +51,6 @@ uint8_t compute_init(acc_data_t *bmsdata)
 				  sizeof(channel_1_buf) / sizeof(uint32_t)));
 
 	return 0;
-}
-
-void compute_enable_charging(bool enable_charging)
-{
-	is_charging_enabled = enable_charging;
-}
-
-bool compute_charger_connected()
-{
-#ifdef CHARGING
-	return true;
-#endif
-	//TODO need to set up CAN msg that actually toggles this bool
-	return false; //bmsdata->is_charger_connected;
 }
 
 // TODO add this back

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -317,6 +317,7 @@ int main(void)
 
   acc_data_t *acc_data = malloc(sizeof(acc_data_t));
   acc_data->is_charger_connected = false;
+  acc_data->is_charging_enabled = false;
   acc_data->fault_code_crit = FAULTS_CLEAR;
   acc_data->fault_code_noncrit = FAULTS_CLEAR;
   
@@ -392,10 +393,10 @@ int main(void)
   /* USER CODE BEGIN RTOS_THREADS */
   
   /* Messaging */
-  can_dispatch_handle = osThreadNew(vCanDispatch, &hcan1, &can_dispatch_attributes);
+  can_dispatch_handle = osThreadNew(vCanDispatch, acc_data, &can_dispatch_attributes);
   assert(can_dispatch_handle);
   
-  can_receive_thread = osThreadNew(vCanReceive, NULL, &can_receive_attributes);
+  can_receive_thread = osThreadNew(vCanReceive, acc_data, &can_receive_attributes);
   assert(can_receive_thread);
 
   get_segment_data_thread = osThreadNew(vGetSegmentData, acc_data, &get_segment_data_attrs);

--- a/Core/Src/stateMachine.c
+++ b/Core/Src/stateMachine.c
@@ -75,7 +75,7 @@ void handle_boot(acc_data_t *bmsdata)
 {
 	prevAccData = NULL;
 	segment_disable_balancing(bmsdata);
-	compute_enable_charging(false);
+	bmsdata->is_charging_enabled = false;
 	start_timer(&bootup_timer, 10000);
 	printf("Bootup timer started\r\n");
 
@@ -89,14 +89,14 @@ void handle_boot(acc_data_t *bmsdata)
 void init_ready(acc_data_t *bmsdata)
 {
 	segment_disable_balancing(bmsdata);
-	compute_enable_charging(false);
+	bmsdata->is_charging_enabled = false;
 	return;
 }
 
 void handle_ready(acc_data_t *bmsdata)
 {
 	/* check for charger connection */
-	if (compute_charger_connected() &&
+	if (bmsdata->is_charger_connected &&
 	    is_timer_expired(&bootup_timer)) { // TODO Fix once charger works
 		request_transition(bmsdata, READY_STATE);
 	} else {
@@ -114,16 +114,16 @@ void init_charging(acc_data_t *bmsdata)
 // TODO: Improve algorithm. Change for new cells. Make more configurable.
 void handle_charging(acc_data_t *bmsdata)
 {
-	if (!compute_charger_connected()) {
+	if (!bmsdata->is_charger_connected) {
 		request_transition(bmsdata, READY_STATE);
 		return;
 
 	} else {
 		/* Check if we should charge */
 		if (sm_charging_check(bmsdata))
-			compute_enable_charging(true);
+			bmsdata->is_charging_enabled = true;
 		else {
-			compute_enable_charging(false);
+			bmsdata->is_charging_enabled = false;
 			send_charging_message(0, 0, bmsdata);
 		}
 
@@ -147,10 +147,16 @@ void handle_charging(acc_data_t *bmsdata)
 	}
 }
 
+void charger_message_recieved(acc_data_t *bmsdata)
+{
+	bmsdata->is_charger_connected = true;
+	handle_charging(bmsdata);
+}
+
 void init_faulted(acc_data_t *bmsdata)
 {
 	segment_disable_balancing(bmsdata);
-	compute_enable_charging(false);
+	bmsdata->is_charging_enabled = false;
 	entered_faulted = true;
 	return;
 }
@@ -195,8 +201,6 @@ void sm_handle_state(acc_data_t *bmsdata)
 	}
 
 	handler_LUT[current_state](bmsdata);
-
-	bmsdata->is_charger_connected = compute_charger_connected();
 
 	sm_broadcast_current_limit(bmsdata);
 }
@@ -387,7 +391,7 @@ bool sm_fault_eval(fault_eval_t *item)
  * trying to start again */
 bool sm_charging_check(acc_data_t *bmsdata)
 {
-	if (!compute_charger_connected()) {
+	if (!bmsdata->is_charger_connected) {
 		printf("Charger not connected\r\n");
 		return false;
 	}
@@ -431,7 +435,7 @@ bool sm_charging_check(acc_data_t *bmsdata)
 // TODO: Improve algorithm.
 bool sm_balancing_check(acc_data_t *bmsdata)
 {
-	if (!compute_charger_connected())
+	if (!bmsdata->is_charger_connected)
 		return false;
 	if (bmsdata->max_temp.val > MAX_CELL_TEMP_BAL)
 		return false;


### PR DESCRIPTION
## Changes
There were a few already-existing (but unused) charging functions, so I built my changes on top of them. Idk charging lore so I may have used them incorrectly, but basically:
1. Charging message is received (verified this worked earlier this month)
2. Then, `vCanRecieve()` calls `charger_message_recieved()` (new function)
3. `charger_message_recieved()` sets `bmsdata->is_charger_connected = true`, and then calls `handle_charging()` (already-existing function)
4. `handle_charging()` does all its checks and sets `bmsdata->is_charging_enabled` accordingly

Also, when `bmsdata->is_charger_connected` is true, `vCanDispatch()` sends messages on CAN2

## Notes
Not tested yet

## Test Cases
It works

## Checklist
- [x] No merge conflicts
- [x] All checks passing
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #190 
